### PR TITLE
[FEAT/MM-157] 스냅샷 기반 네비게이션 전환 도입

### DIFF
--- a/apps/react/package.json
+++ b/apps/react/package.json
@@ -32,6 +32,7 @@
     "lodash-es": "^4.17.21",
     "lottie-react": "^2.4.1",
     "lucide-react": "catalog:react",
+    "motion": "^12.23.24",
     "path-to-regexp": "catalog:",
     "react": "catalog:react",
     "react-dom": "catalog:react",

--- a/apps/react/package.json
+++ b/apps/react/package.json
@@ -29,6 +29,7 @@
     "clsx": "catalog:react",
     "event-source-polyfill": "^1.0.31",
     "framer-motion": "^12.23.12",
+    "lodash-es": "^4.17.21",
     "lottie-react": "^2.4.1",
     "lucide-react": "catalog:react",
     "path-to-regexp": "catalog:",

--- a/apps/react/src/app/__root.tsx
+++ b/apps/react/src/app/__root.tsx
@@ -1,10 +1,13 @@
 import { QueryClient } from '@tanstack/react-query'
-import { createRootRouteWithContext, Outlet, redirect } from '@tanstack/react-router'
+import { createRootRouteWithContext, redirect } from '@tanstack/react-router'
 import { match } from 'path-to-regexp'
 
 import { AuthContext } from '@/features/auth/hooks/use-auth'
 import { CoupleStatusProvider } from '@/features/member'
 import { useTheme } from '@/shared/contexts/theme.context'
+import { NavigationTransitionProvider } from '@/shared/navigation/transition'
+import { StackedOutlet } from '@/shared/ui/stacked-outlet'
+import { TransitionViewport } from '@/shared/ui/transition-viewport'
 
 interface RouterContext {
   queryClient: QueryClient
@@ -81,7 +84,11 @@ function RootComponent() {
           style={{ backgroundColor: statusColor }}
         />
         <CoupleStatusProvider>
-          <Outlet />
+          <NavigationTransitionProvider>
+            <TransitionViewport>
+              <StackedOutlet />
+            </TransitionViewport>
+          </NavigationTransitionProvider>
         </CoupleStatusProvider>
       </main>
     </div>

--- a/apps/react/src/app/__root.tsx
+++ b/apps/react/src/app/__root.tsx
@@ -1,12 +1,12 @@
 import { QueryClient } from '@tanstack/react-query'
-import { createRootRouteWithContext, redirect } from '@tanstack/react-router'
+import { createRootRouteWithContext, redirect, useRouterState } from '@tanstack/react-router'
 import { match } from 'path-to-regexp'
 
 import { AuthContext } from '@/features/auth/hooks/use-auth'
 import { CoupleStatusProvider } from '@/features/member'
 import { useTheme } from '@/shared/contexts/theme.context'
 import { NavigationTransitionProvider } from '@/shared/navigation/transition'
-import { StackedOutlet } from '@/shared/ui/stacked-outlet'
+import { NavigationOutlet, StackedOutlet } from '@/shared/ui/stacked-outlet'
 import { TransitionViewport } from '@/shared/ui/transition-viewport'
 
 interface RouterContext {
@@ -74,6 +74,10 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 function RootComponent() {
   const { statusColor } = useTheme()
+  const currentPath = useRouterState({
+    select: (state) => state.location.pathname,
+  })
+  const isOnboardingRoute = matchRoute(onboardingRoutes, currentPath)
 
   return (
     <div className="no-bounce-scroll main-scrollable app-safe flex h-screen w-full flex-col bg-white">
@@ -85,9 +89,7 @@ function RootComponent() {
         />
         <CoupleStatusProvider>
           <NavigationTransitionProvider>
-            <TransitionViewport>
-              <StackedOutlet />
-            </TransitionViewport>
+            <TransitionViewport>{isOnboardingRoute ? <NavigationOutlet /> : <StackedOutlet />}</TransitionViewport>
           </NavigationTransitionProvider>
         </CoupleStatusProvider>
       </main>

--- a/apps/react/src/app/__root.tsx
+++ b/apps/react/src/app/__root.tsx
@@ -74,7 +74,7 @@ function RootComponent() {
 
   return (
     <div className="no-bounce-scroll main-scrollable app-safe flex h-screen w-full flex-col bg-white">
-      <main className="relative mx-auto flex w-full max-w-[600px] flex-1 flex-col">
+      <main className="relative mx-auto flex min-h-0 w-full max-w-[600px] flex-1 flex-col">
         <div
           aria-hidden
           className="pointer-events-none fixed inset-x-0 top-0 z-40 h-[var(--safe-top)]"

--- a/apps/react/src/app/attachment-test/page.tsx
+++ b/apps/react/src/app/attachment-test/page.tsx
@@ -7,7 +7,10 @@ import { useAuth } from '@/features/auth'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useTheme } from '@/shared/contexts/theme.context'
+import { Screen } from '@/shared/layout/screen'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import { Button } from '@/shared/ui'
+import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
 const searchSchema = z.object({
   from: z.string().optional(),
@@ -20,6 +23,7 @@ export const Route = createFileRoute('/attachment-test/')({
 
 function AttachmentTestPage() {
   const navigate = useNavigate()
+  const goBack = useGoBack()
   const { setStatusColor } = useTheme()
   const { from } = useSearch({ from: Route.id })
   const { userInfo } = useAuth()
@@ -38,28 +42,43 @@ function AttachmentTestPage() {
   )
 
   return (
-    <div className="relative flex h-full w-full flex-col bg-malmo-rasberry-25">
-      {/* 상단 라즈베리 배경 섹션 */}
-      <AttachmentTestIntro nickname={nickname} from={from} />
-
-      {/* 흰색 섹션 */}
-      <div className="-mt-1 flex-1 rounded-t-[24px] bg-white">
-        <div className="mt-[48px] px-[20px]">
-          {/* 애착유형 검사 소개 섹션 */}
-          <AttachmentTestInfoSection />
-
-          {/* 애착유형 소개 섹션 */}
-          <AttachmentTypesSection />
-
-          {/* 플로팅 버튼을 위한 하단 여백 */}
-          <div className="pb-[154px]"></div>
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <div className="bg-malmo-rasberry-25">
+          <DetailHeaderBar
+            onBackClick={() => {
+              if (from) {
+                navigate({ to: from })
+              } else {
+                goBack()
+              }
+            }}
+            className="bg-malmo-rasberry-25"
+          />
         </div>
-      </div>
+      </Screen.Header>
 
-      {/* 플로팅 버튼 */}
-      <div className="fixed right-0 bottom-[var(--safe-bottom)] left-0 z-10 flex justify-center px-5 py-4">
-        <Button text="시작하기" onClick={handleStartTest} />
-      </div>
-    </div>
+      <Screen.Content className="relative flex h-full w-full flex-col bg-malmo-rasberry-25">
+        {/* 상단 라즈베리 배경 섹션 */}
+        <AttachmentTestIntro nickname={nickname} from={from} />
+
+        {/* 흰색 섹션 */}
+        <div className="-mt-1 flex-1 rounded-t-[24px] bg-white">
+          <div className="mt-[48px] px-[20px]">
+            {/* 애착유형 검사 소개 섹션 */}
+            <AttachmentTestInfoSection />
+
+            {/* 애착유형 소개 섹션 */}
+            <AttachmentTypesSection />
+            <div className="pb-[154px]"></div>
+          </div>
+        </div>
+
+        {/* 플로팅 버튼 */}
+        <div className="fixed right-0 bottom-[var(--safe-bottom)] left-0 z-10 flex justify-center px-5 py-4">
+          <Button text="시작하기" onClick={handleStartTest} />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/attachment-test/page.tsx
+++ b/apps/react/src/app/attachment-test/page.tsx
@@ -60,7 +60,7 @@ function AttachmentTestPage() {
 
       <Screen.Content className="relative flex h-full w-full flex-col bg-malmo-rasberry-25">
         {/* 상단 라즈베리 배경 섹션 */}
-        <AttachmentTestIntro nickname={nickname} from={from} />
+        <AttachmentTestIntro nickname={nickname} />
 
         {/* 흰색 섹션 */}
         <div className="-mt-1 flex-1 rounded-t-[24px] bg-white">

--- a/apps/react/src/app/attachment-test/question/page.tsx
+++ b/apps/react/src/app/attachment-test/question/page.tsx
@@ -12,6 +12,7 @@ import {
 import { useAuth } from '@/features/auth'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import loveTypeService from '@/shared/services/love-type.service'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -77,43 +78,41 @@ function AttachmentTestQuestionPage() {
   }
 
   return (
-    <div className="flex h-[calc(100vh-var(--safe-top))] w-full flex-col bg-white">
-      {/* 헤더 */}
-      <DetailHeaderBar onBackClick={handleGoBackWithTracking} />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={handleGoBackWithTracking} />
+      </Screen.Header>
 
-      {/* 진행 상태 표시 */}
-      <QuestionProgress
-        currentPage={currentPage}
-        totalPages={totalPages}
-        questionsPerPage={QUESTION_CONFIG.QUESTIONS_PER_PAGE}
-      />
-
-      {/* 구분선 */}
-      <hr className="mx-[20px] mt-[40px] mb-[16px] h-[1px] border-0 bg-gray-iron-200" />
-
-      {/* 질문 목록 */}
-      <div className="flex-1 overflow-y-auto">
-        <QuestionList
-          questions={currentQuestions}
-          answers={answers}
-          onSelectAnswer={handleSelectAnswerWithTracking}
-          setQuestionRef={setQuestionRef}
-          loading={loading}
-          error={error}
+      <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <QuestionProgress
+          currentPage={currentPage}
+          totalPages={totalPages}
+          questionsPerPage={QUESTION_CONFIG.QUESTIONS_PER_PAGE}
         />
-      </div>
 
-      {/* 다음 버튼 */}
-      <div className="mt-auto mb-10 px-5">
-        <Button
-          text={currentPage === totalPages ? '완료하기' : '다음'}
-          onClick={handleNextWithTracking}
-          disabled={loading || !isCurrentPageComplete}
-        />
-      </div>
+        <hr className="mx-[20px] mt-[40px] mb-[16px] h-[1px] border-0 bg-gray-iron-200" />
 
-      {/* 애착유형 검사 가이드 바텀 시트 */}
+        <div className="flex-1 overflow-y-auto">
+          <QuestionList
+            questions={currentQuestions}
+            answers={answers}
+            onSelectAnswer={handleSelectAnswerWithTracking}
+            setQuestionRef={setQuestionRef}
+            loading={loading}
+            error={error}
+          />
+        </div>
+
+        <div className="mt-auto mb-10 px-5">
+          <Button
+            text={currentPage === totalPages ? '완료하기' : '다음'}
+            onClick={handleNextWithTracking}
+            disabled={loading || !isCurrentPageComplete}
+          />
+        </div>
+      </Screen.Content>
+
       <AttachmentTestGuide isOpen={isGuideOpen} onClose={handleCloseGuide} />
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/chat/loading/page.tsx
+++ b/apps/react/src/app/chat/loading/page.tsx
@@ -4,6 +4,7 @@ import Lottie from 'lottie-react'
 import { useEffect } from 'react'
 
 import summaryAnimation from '@/assets/lottie/summary.json'
+import { Screen } from '@/shared/layout/screen'
 import chatService from '@/shared/services/chat.service'
 
 export const Route = createFileRoute('/chat/loading/')({
@@ -37,14 +38,14 @@ function RouteComponent() {
   }, [])
 
   return (
-    <div className="app-safe fixed inset-0 z-0">
-      <div className="flex h-full w-full -translate-y-[60px] flex-col items-center justify-center gap-6">
+    <Screen>
+      <Screen.Content className="flex h-full w-full -translate-y-[60px] flex-col items-center justify-center gap-6">
         <Lottie animationData={summaryAnimation} className="px-7" />
         <div className="text-center">
           <h1 className="heading1-bold text-gray-iron-950">모모가 대화를 요약하고 있어요</h1>
           <p className="body2-medium text-gray-iron-500">조금만 기다려주세요!</p>
         </div>
-      </div>
-    </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/chat/page.tsx
+++ b/apps/react/src/app/chat/page.tsx
@@ -3,7 +3,7 @@ import {
   ChatRoomMessageDataSenderTypeEnum,
   ChatRoomStateDataChatRoomStateEnum,
 } from '@data/user-api-axios/api'
-import { createFileRoute, Link, useNavigate, useRouter } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { ChevronRight } from 'lucide-react'
 import React, { useCallback, useMemo } from 'react'
 import { z } from 'zod'
@@ -24,7 +24,9 @@ import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useInfiniteScroll } from '@/shared/hooks/use-infinite-scroll'
 import { useKeyboardSheetMotion } from '@/shared/hooks/use-keyboard-motion'
+import { Screen } from '@/shared/layout/screen'
 import { cn } from '@/shared/lib/cn'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import chatService from '@/shared/services/chat.service'
 import historyService from '@/shared/services/history.service'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -57,8 +59,8 @@ LoadingIndicator.displayName = 'LoadingIndicator'
 
 function RouteComponent() {
   const { chatId } = Route.useLoaderData()
-  const router = useRouter()
   const navigate = useNavigate()
+  const goBack = useGoBack()
   const { chatStatus, chattingModal, streamingMessage, isChatStatusSuccess, sendingMessage } = useChatting()
   const auth = useAuth()
   const { keyboardBottom } = useKeyboardSheetMotion()
@@ -109,74 +111,83 @@ function RouteComponent() {
   )
 
   return (
-    <>
-      <div className="app-safe fixed top-0 flex h-screen flex-col" style={keyboardBottom}>
+    <Screen>
+      <Screen.Header behavior="overlay">
         <DetailHeaderBar
           right={chatId ? undefined : exitButton()}
           title={chatId ? formatDate(messages[0]?.createdAt, 'YYYY년 MM월 DD일') : ''}
-          onBackClick={() => (chatId ? router.history.back() : chattingModal.exitChattingModal())}
+          onBackClick={() => {
+            if (chatId) {
+              goBack()
+            } else {
+              chattingModal.exitChattingModal()
+            }
+          }}
         />
+      </Screen.Header>
 
-        <section className="no-bounce-scroll flex flex-1 flex-col overflow-y-auto" ref={scrollRef}>
-          <div className="bg-gray-iron-700 px-[20px] py-[9px]">
-            <p className="body3-medium text-center text-white">
-              대화 내용은 연인에게 공유 또는 유출되지 않으니 안심하세요!
-            </p>
-          </div>
-
-          {isLoading && (
-            <div className="flex flex-1 items-center justify-center">
-              <LoadingIndicator isFetching={true} />
+      <Screen.Content className="flex h-full flex-col">
+        <div className="flex flex-1 flex-col" style={keyboardBottom}>
+          <section className="no-bounce-scroll flex flex-1 flex-col overflow-y-auto" ref={scrollRef}>
+            <div className="bg-gray-iron-700 px-[20px] py-[9px]">
+              <p className="body3-medium text-center text-white">
+                대화 내용은 연인에게 공유 또는 유출되지 않으니 안심하세요!
+              </p>
             </div>
-          )}
 
-          {!chatId && hasNextPage && <LoadingIndicator ref={ref} isFetching={isFetchingNextPage} />}
-
-          <div className="flex flex-col gap-6 px-5 py-[22px]">
-            {messages.map((chat, index) => {
-              const previousTimestamp = index > 0 ? messages[index - 1]?.createdAt : undefined
-              return (
-                <React.Fragment key={`${chat.messageId}-${index}`}>
-                  <DateDivider currentTimestamp={chat.createdAt} previousTimestamp={previousTimestamp} />
-                  {chat.senderType === ChatRoomMessageDataSenderTypeEnum.Assistant ? (
-                    <AiChatBubble message={chat.content} timestamp={formatTimestamp(chat.createdAt)} />
-                  ) : (
-                    <MyChatBubble
-                      message={chat.content}
-                      timestamp={formatTimestamp(chat.createdAt)}
-                      status={(chat as ChatRoomMessageData & ChatMessageTempStatus).status ?? 'sent'}
-                      onRetry={() => handleRetry(chat.content!)}
-                    />
-                  )}
-                </React.Fragment>
-              )
-            })}
-
-            {streamingMessage && (
-              <AiChatBubble
-                message={streamingMessage.content}
-                timestamp={formatTimestamp(streamingMessage.createdAt)}
-              />
+            {isLoading && (
+              <div className="flex flex-1 items-center justify-center">
+                <LoadingIndicator isFetching={true} />
+              </div>
             )}
 
-            {chatStatus === ChatRoomStateDataChatRoomStateEnum.Paused && (
-              <Link
-                to="/my-page"
-                className="mt-[-12px] ml-[62px] flex w-fit items-center gap-1 rounded-[8px] border border-malmo-rasberry-300 py-2 pr-[12px] pl-[18px] text-malmo-rasberry-500 shadow-[1px_3px_8px_rgba(0,0,0,0.08)]"
-                onClick={wrapWithTracking(BUTTON_NAMES.GO_MYPAGE_FROM_CHAT, CATEGORIES.CHAT)}
-              >
-                <p className="body3-semibold">마이페이지로 이동하기</p>
-                <ChevronRight className="h-4 w-4" />
-              </Link>
-            )}
-          </div>
+            {!chatId && hasNextPage && <LoadingIndicator ref={ref} isFetching={isFetchingNextPage} />}
 
-          {chatId && hasNextPage && <LoadingIndicator ref={ref} isFetching={isFetchingNextPage} />}
-        </section>
+            <div className="flex flex-col gap-6 px-5 py-[22px]">
+              {messages.map((chat, index) => {
+                const previousTimestamp = index > 0 ? messages[index - 1]?.createdAt : undefined
+                return (
+                  <React.Fragment key={`${chat.messageId}-${index}`}>
+                    <DateDivider currentTimestamp={chat.createdAt} previousTimestamp={previousTimestamp} />
+                    {chat.senderType === ChatRoomMessageDataSenderTypeEnum.Assistant ? (
+                      <AiChatBubble message={chat.content} timestamp={formatTimestamp(chat.createdAt)} />
+                    ) : (
+                      <MyChatBubble
+                        message={chat.content}
+                        timestamp={formatTimestamp(chat.createdAt)}
+                        status={(chat as ChatRoomMessageData & ChatMessageTempStatus).status ?? 'sent'}
+                        onRetry={() => handleRetry(chat.content!)}
+                      />
+                    )}
+                  </React.Fragment>
+                )
+              })}
 
-        <ChatInput disabled={!!chatId} />
-      </div>
+              {streamingMessage && (
+                <AiChatBubble
+                  message={streamingMessage.content}
+                  timestamp={formatTimestamp(streamingMessage.createdAt)}
+                />
+              )}
+
+              {chatStatus === ChatRoomStateDataChatRoomStateEnum.Paused && (
+                <Link
+                  to="/my-page"
+                  className="mt-[-12px] ml-[62px] flex w-fit items-center gap-1 rounded-[8px] border border-malmo-rasberry-300 py-2 pr-[12px] pl-[18px] text-malmo-rasberry-500 shadow-[1px_3px_8px_rgba(0,0,0,0.08)]"
+                  onClick={wrapWithTracking(BUTTON_NAMES.GO_MYPAGE_FROM_CHAT, CATEGORIES.CHAT)}
+                >
+                  <p className="body3-semibold">마이페이지로 이동하기</p>
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              )}
+            </div>
+
+            {chatId && hasNextPage && <LoadingIndicator ref={ref} isFetching={isFetchingNextPage} />}
+          </section>
+          <ChatInput disabled={!!chatId} />
+        </div>
+      </Screen.Content>
       {chattingModal.showChattingTutorial && chattingModal.chattingTutorialModal()}
-    </>
+    </Screen>
   )
 }

--- a/apps/react/src/app/chat/result/page.tsx
+++ b/apps/react/src/app/chat/result/page.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { X } from 'lucide-react'
 import { useEffect } from 'react'
 import { z } from 'zod'
@@ -9,7 +9,9 @@ import { useHistoryModal } from '@/features/history/hooks/use-history-modal'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useTheme } from '@/shared/contexts/theme.context'
+import { Screen } from '@/shared/layout/screen'
 import { cn } from '@/shared/lib/cn'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import historyService from '@/shared/services/history.service'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -41,6 +43,7 @@ function RouteComponent() {
   const { data: chatResult } = useQuery(historyService.historySummaryQuery(chatId ?? loaderChatId))
 
   const navigate = useNavigate()
+  const goBack = useGoBack()
 
   useEffect(() => {
     setStatusColor('#FDEDF0')
@@ -67,20 +70,27 @@ function RouteComponent() {
         <p className="body2-medium text-gray-iron-700">{chatId ? '삭제' : '로딩중'}</p>
       </div>
     ) : (
-      <Link to="/" onClick={wrapWithTracking(BUTTON_NAMES.CLOSE_RESULT, CATEGORIES.CHAT, () => {})}>
+      <button
+        type="button"
+        className="rounded border-none bg-transparent p-1 text-gray-iron-950"
+        onClick={wrapWithTracking(BUTTON_NAMES.CLOSE_RESULT, CATEGORIES.CHAT, () => goBack())}
+      >
         <X className="h-[24px] w-[24px]" />
-      </Link>
+      </button>
     )
 
   return (
-    <div className="flex h-full flex-col bg-white pt-[50px]">
-      <DetailHeaderBar
-        right={exitButton()}
-        showBackButton={fromHistory}
-        className="fixed top-[var(--safe-top)] bg-malmo-rasberry-25"
-      />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar
+          right={exitButton()}
+          showBackButton={fromHistory}
+          onBackClick={goBack}
+          className="bg-malmo-rasberry-25"
+        />
+      </Screen.Header>
 
-      <div className="flex flex-col bg-malmo-rasberry-25 pt-3">
+      <Screen.Content className="flex flex-col bg-malmo-rasberry-25 pt-3">
         <ChatResultHeader
           title="대화 요약이 완료되었어요!"
           description={'모모가 고민을 해결하는 데<br /> 도움을 주었길 바라요'}
@@ -117,14 +127,12 @@ function RouteComponent() {
             <div className="mt-20">
               <Button
                 text="홈으로 이동하기"
-                onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.CHAT, () =>
-                  navigate({ to: '/' })
-                )}
+                onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.CHAT, () => goBack())}
               />
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/history/delete/page.tsx
+++ b/apps/react/src/app/history/delete/page.tsx
@@ -5,6 +5,7 @@ import { useChatHistoryQuery } from '@/features/history/hooks/use-chat-history-q
 import { useChatSelect } from '@/features/history/hooks/use-chat-select'
 import { EmptyState, SelectableChatHistoryItem } from '@/features/history/ui/chat-history-item'
 import { useInfiniteScroll } from '@/shared/hooks/use-infinite-scroll'
+import { Screen } from '@/shared/layout/screen'
 import { cn } from '@/shared/lib/cn'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -23,12 +24,17 @@ function RouteComponent() {
   const showEmpty = !isFetchingNextPage && histories.length === 0
 
   return (
-    <div className="relative flex h-full flex-col overflow-hidden pt-[50px]">
-      <div className="fixed top-[var(--safe-top)] z-20 bg-white">
-        <DetailHeaderBar title="삭제" left={backButton()} className="border-b-[1px] border-b-gray-iron-100" />
-      </div>
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar
+          title="삭제"
+          left={backButton()}
+          onBackClick={() => backButton()?.props?.onClick?.({ state: { skipTransition: true } })}
+          className="border-b border-b-gray-iron-100 bg-white"
+        />
+      </Screen.Header>
 
-      <section className="flex-1 overflow-y-auto bg-gray-neutral-100 pb-28">
+      <Screen.Content className="relative overflow-y-auto bg-gray-neutral-100 pt-[calc(var(--safe-top)+50px)] pb-[calc(var(--safe-bottom)+96px)]">
         {showEmpty ? (
           <EmptyState
             image={noResultImage}
@@ -49,16 +55,20 @@ function RouteComponent() {
             {isFetchingNextPage && <p className="p-5 text-center">더 불러오는 중...</p>}
           </>
         )}
-      </section>
+      </Screen.Content>
 
-      <div className="fixed inset-x-0 bottom-[calc(var(--safe-bottom)+20px)] z-50 px-5">
-        <Button
-          onClick={handleDelete}
-          text={selectedIds.length > 0 ? `${selectedIds.length}개 삭제` : '삭제'}
-          disabled={selectedIds.length === 0}
-          className={cn('bg-gray-iron-700', { 'cursor-not-allowed bg-gray-neutral-300': selectedIds.length === 0 })}
-        />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-50">
+        <div className="pointer-events-auto px-5 pb-[calc(var(--safe-bottom)+20px)]">
+          <Button
+            onClick={handleDelete}
+            text={selectedIds.length > 0 ? `${selectedIds.length}개 삭제` : '삭제'}
+            disabled={selectedIds.length === 0}
+            className={cn('bg-gray-iron-700', {
+              'cursor-not-allowed bg-gray-neutral-300': selectedIds.length === 0,
+            })}
+          />
+        </div>
       </div>
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/history/page.tsx
+++ b/apps/react/src/app/history/page.tsx
@@ -13,6 +13,7 @@ import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useDebounce } from '@/shared/hooks/use-debounce'
 import { useInfiniteScroll } from '@/shared/hooks/use-infinite-scroll'
+import { Screen } from '@/shared/layout/screen'
 import { cn } from '@/shared/lib/cn'
 import chatService from '@/shared/services/chat.service'
 import { BottomNavigation } from '@/shared/ui'
@@ -56,39 +57,41 @@ function RouteComponent() {
   const handleChatFAB = wrapWithTracking(BUTTON_NAMES.OPEN_CHAT_FAB, CATEGORIES.MAIN, () => {})
 
   return (
-    <div className="has-bottom-nav flex h-full flex-col pt-30">
-      <div className="fixed top-[var(--safe-top)] z-20 bg-white">
-        <HomeHeaderBar
-          title="대화 기록"
-          right={
-            <Link to={'/history/delete'} onClick={handleDeleteMode}>
-              <p className="body2-medium text-gray-iron-700">삭제</p>
-            </Link>
-          }
-        />
-        <div className="px-5 pb-3">
-          <div className="relative flex items-center">
-            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
-              <LucideSearch size={20} className="text-gray-iron-800" />
-            </div>
-            <input
-              type="text"
-              placeholder="찾고 싶은 대화 제목을 검색해 보세요"
-              className="w-full rounded-[42px] bg-gray-neutral-100 py-[13px] pr-10 pl-12 text-gray-iron-900 placeholder:text-gray-iron-400 focus:outline-none"
-              value={keyword}
-              onChange={handleSearchChange}
-            />
-            {isLoading && (
-              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-4">
-                <Spinner className="h-5 w-5 text-gray-iron-400" />
+    <Screen>
+      <Screen.Header>
+        <div className="bg-white">
+          <HomeHeaderBar
+            title="대화 기록"
+            right={
+              <Link to={'/history/delete'} state={{ skipTransition: true }} onClick={handleDeleteMode}>
+                <p className="body2-medium text-gray-iron-700">삭제</p>
+              </Link>
+            }
+          />
+          <div className="px-5 pb-3">
+            <div className="relative flex items-center">
+              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+                <LucideSearch size={20} className="text-gray-iron-800" />
               </div>
-            )}
+              <input
+                type="text"
+                placeholder="찾고 싶은 대화 제목을 검색해 보세요"
+                className="w-full rounded-[42px] bg-gray-neutral-100 py-[13px] pr-10 pl-12 text-gray-iron-900 placeholder:text-gray-iron-400 focus:outline-none"
+                value={keyword}
+                onChange={handleSearchChange}
+              />
+              {isLoading && (
+                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-4">
+                  <Spinner className="h-5 w-5 text-gray-iron-400" />
+                </div>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </Screen.Header>
 
-      <section
-        className={`min-h-0 flex-1 bg-gray-neutral-100 transition-opacity ${histories.length === 0 || isLoading ? 'overflow-hidden' : 'overflow-y-auto'}`}
+      <Screen.Content
+        className={`has-bottom-nav min-h-0 flex-1 bg-gray-neutral-100 transition-opacity ${histories.length === 0 || isLoading ? 'overflow-hidden' : 'overflow-y-auto'}`}
       >
         {isLoading ? (
           <div className="flex h-full items-center justify-center">
@@ -112,7 +115,7 @@ function RouteComponent() {
             {isFetchingNextPage && <p className="p-5 text-center">더 불러오는 중...</p>}
           </>
         )}
-      </section>
+      </Screen.Content>
 
       <Link to={'/chat'} onClick={handleChatFAB}>
         <div className="fixed right-5 bottom-[calc(var(--safe-bottom)+var(--bottom-nav-h)+16px)] z-50 flex h-[52px] w-[52px] items-center justify-center rounded-full bg-gray-iron-700">
@@ -131,6 +134,6 @@ function RouteComponent() {
       </Link>
 
       <BottomNavigation />
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/intro/page.tsx
+++ b/apps/react/src/app/intro/page.tsx
@@ -7,6 +7,8 @@ import dailyQuestionImage from '@/assets/images/introduce/daily-question.png'
 import momoIntroImage from '@/assets/images/introduce/momo-intro.png'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import { Button } from '@/shared/ui/button'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
@@ -48,6 +50,7 @@ export const Route = createFileRoute('/intro/')({
 function IntroPage() {
   const [currentPage, setCurrentPage] = useState(0)
   const navigate = useNavigate()
+  const goBack = useGoBack()
 
   // 현재 페이지 데이터
   const currentData = introPages[currentPage]
@@ -88,69 +91,67 @@ function IntroPage() {
   const handlePrevious = wrapWithTracking(BUTTON_NAMES.PREV_INTRO, CATEGORIES.AUTH, () => {
     if (currentPage > 0) {
       setCurrentPage((prev) => prev - 1)
+    } else {
+      goBack()
     }
   })
 
   return (
-    <div className="flex h-full w-full flex-col bg-white">
-      <DetailHeaderBar onBackClick={handlePrevious} showBackButton={currentPage > 0} />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={handlePrevious} showBackButton={true} />
+      </Screen.Header>
 
-      {/* 메인 콘텐츠 */}
-      <div className="flex flex-1 flex-col justify-center">
-        {/* 이미지 */}
-        <div className="flex justify-center">
-          <div className="h-[236px] w-[320px]">
-            <img src={currentData.image} alt={currentData.title} className="h-full w-full object-contain" />
+      <Screen.Content className="flex flex-1 flex-col bg-white">
+        <div className="flex flex-1 flex-col justify-center">
+          <div className="flex justify-center">
+            <div className="h-[236px] w-[320px]">
+              <img src={currentData.image} alt={currentData.title} className="h-full w-full object-contain" />
+            </div>
+          </div>
+
+          <h1 className="title2-bold mt-6 text-center text-gray-iron-950">
+            {currentData.title.split('\n').map((line, index) => (
+              <React.Fragment key={index}>
+                {line}
+                {index < currentData.title.split('\n').length - 1 && <br />}
+              </React.Fragment>
+            ))}
+          </h1>
+
+          <p className="body2-medium mt-4 text-center text-gray-iron-400">
+            {currentData.description.split('\n').map((line, index) => (
+              <React.Fragment key={index}>
+                {line}
+                {index < currentData.description.split('\n').length - 1 && <br />}
+              </React.Fragment>
+            ))}
+          </p>
+        </div>
+
+        <div className="flex flex-col pb-[var(--safe-bottom)]">
+          <div className="mb-8 flex justify-center space-x-2">
+            {introPages.map((_, index) => (
+              <div
+                key={index}
+                className={`h-2 rounded-full ${
+                  index === currentPage ? 'w-4 bg-malmo-rasberry-500' : 'w-2 bg-gray-neutral-200'
+                }`}
+              />
+            ))}
+          </div>
+
+          <div className="mb-5 px-6">
+            <Button text={isLastPage ? '시작하기' : '다음'} onClick={handleNext} className="w-full" />
+          </div>
+
+          <div className="mb-5 flex justify-center">
+            <button onClick={handleSkip} className="body3-medium text-gray-iron-400">
+              건너뛰기
+            </button>
           </div>
         </div>
-
-        {/* 타이틀 */}
-        <h1 className="title2-bold mt-6 text-center text-gray-iron-950">
-          {currentData.title.split('\n').map((line, index) => (
-            <React.Fragment key={index}>
-              {line}
-              {index < currentData.title.split('\n').length - 1 && <br />}
-            </React.Fragment>
-          ))}
-        </h1>
-
-        {/* 설명 */}
-        <p className="body2-medium mt-4 text-center text-gray-iron-400">
-          {currentData.description.split('\n').map((line, index) => (
-            <React.Fragment key={index}>
-              {line}
-              {index < currentData.description.split('\n').length - 1 && <br />}
-            </React.Fragment>
-          ))}
-        </p>
-      </div>
-
-      {/* 하단 고정 영역 */}
-      <div className="flex flex-col pb-[var(--safe-bottom)]">
-        {/* 페이지 인디케이터 */}
-        <div className="mb-8 flex justify-center space-x-2">
-          {introPages.map((_, index) => (
-            <div
-              key={index}
-              className={`h-2 rounded-full ${
-                index === currentPage ? 'w-4 bg-malmo-rasberry-500' : 'w-2 bg-gray-neutral-200'
-              }`}
-            />
-          ))}
-        </div>
-
-        {/* 다음/시작하기 버튼 */}
-        <div className="mb-5 px-6">
-          <Button text={isLastPage ? '시작하기' : '다음'} onClick={handleNext} className="w-full" />
-        </div>
-
-        {/* 건너뛰기 */}
-        <div className="mb-5 flex justify-center">
-          <button onClick={handleSkip} className="body3-medium text-gray-iron-400">
-            건너뛰기
-          </button>
-        </div>
-      </div>
-    </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/intro/page.tsx
+++ b/apps/react/src/app/intro/page.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import React, { useState } from 'react'
+import React from 'react'
+import z from 'zod'
 
 import attachmentTypeImage from '@/assets/images/introduce/attachment-type.png'
 import coupleConsultationImage from '@/assets/images/introduce/couple-consultation.png'
@@ -43,14 +44,20 @@ const introPages: IntroPageData[] = [
   },
 ]
 
+const searchSchema = z.object({
+  step: z.number().int().min(0).catch(0),
+})
+
 export const Route = createFileRoute('/intro/')({
+  validateSearch: searchSchema,
   component: IntroPage,
 })
 
 function IntroPage() {
-  const [currentPage, setCurrentPage] = useState(0)
   const navigate = useNavigate()
   const goBack = useGoBack()
+  const { step } = Route.useSearch()
+  const currentPage = Math.min(step ?? 0, introPages.length - 1)
 
   // 현재 페이지 데이터
   const currentData = introPages[currentPage]
@@ -74,7 +81,10 @@ function IntroPage() {
         // 마지막 페이지에서 완료 처리
         handleComplete()
       } else {
-        setCurrentPage((prev) => prev + 1)
+        navigate({
+          to: '/intro',
+          search: (prev) => ({ ...prev, step: currentPage + 1 }),
+        })
       }
     }
   )
@@ -90,7 +100,8 @@ function IntroPage() {
 
   const handlePrevious = wrapWithTracking(BUTTON_NAMES.PREV_INTRO, CATEGORIES.AUTH, () => {
     if (currentPage > 0) {
-      setCurrentPage((prev) => prev - 1)
+      // 이전 단계는 히스토리 pop으로 back 애니메이션
+      goBack()
     } else {
       goBack()
     }

--- a/apps/react/src/app/my-page/account-settings/page.tsx
+++ b/apps/react/src/app/my-page/account-settings/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/features/auth'
 import { useProfileModal } from '@/features/profile'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
 export const Route = createFileRoute('/my-page/account-settings/')({
@@ -38,31 +39,31 @@ function AccountSettingsPage() {
   const handleWithdraw = wrapWithTracking(BUTTON_NAMES.WITHDRAW, CATEGORIES.PROFILE, () => profileModal.withdrawModal())
 
   return (
-    <div className="h-full bg-white">
-      {/* 헤더 */}
-      <DetailHeaderBar title="내 계정" />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar title="내 계정" />
+      </Screen.Header>
 
-      {/* 소셜 계정 */}
-      <div className="flex h-16 items-center justify-between pr-6 pl-5">
-        <div className="flex items-center">
-          <ProviderIcon className="h-7 w-7" />
-          <span className="body1-medium ml-2 text-gray-iron-950">{providerText}</span>
+      <Screen.Content className="bg-white">
+        <div className="flex h-16 items-center justify-between pr-6 pl-5">
+          <div className="flex items-center">
+            <ProviderIcon className="h-7 w-7" />
+            <span className="body1-medium ml-2 text-gray-iron-950">{providerText}</span>
+          </div>
+          <button onClick={handleLogout} className="body2-medium text-gray-iron-950">
+            로그아웃
+          </button>
         </div>
-        <button onClick={handleLogout} className="body2-medium text-gray-iron-950">
-          로그아웃
-        </button>
-      </div>
 
-      {/* 구분선 */}
-      <hr className="h-px border-0 bg-gray-iron-100" />
+        <hr className="h-px border-0 bg-gray-iron-100" />
 
-      {/* 회원 탈퇴 */}
-      <div className="flex h-16 items-center justify-between pr-6 pl-5">
-        <span className="body3-medium text-gray-iron-400">회원 정보를 삭제하시겠어요?</span>
-        <button onClick={handleWithdraw} className="body3-medium text-gray-iron-400">
-          회원 탈퇴
-        </button>
-      </div>
-    </div>
+        <div className="flex h-16 items-center justify-between pr-6 pl-5">
+          <span className="body3-medium text-gray-iron-400">회원 정보를 삭제하시겠어요?</span>
+          <button onClick={handleWithdraw} className="body3-medium text-gray-iron-400">
+            회원 탈퇴
+          </button>
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/my-page/couple-management/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/page.tsx
@@ -9,6 +9,7 @@ import { usePartnerInfo } from '@/features/member/hooks/use-partner-info'
 import { PartnerCodeSheet, useProfileModal } from '@/features/profile'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import memberService from '@/shared/services/member.service'
 import { queryKeys } from '@/shared/services/query-keys'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -65,50 +66,47 @@ function CoupleManagementPage() {
   )
 
   return (
-    <div className="h-full bg-white">
-      {/* 헤더 */}
-      <DetailHeaderBar title="커플 연동 관리" />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar title="커플 연동 관리" />
+      </Screen.Header>
 
-      <div className="px-5">
-        {/* 내 커플 코드 */}
-        <div className="flex h-16 items-center pr-1">
-          <span className="body1-medium text-gray-iron-950">내 커플 코드</span>
-          <div className="ml-auto flex items-center">
-            <span className="body2-medium text-gray-iron-950">{inviteCode}</span>
-            <button onClick={handleCopyInviteCode} className="ml-2">
-              <ClipBoardIcon className="h-4 w-4" />
-            </button>
+      <Screen.Content className="bg-white">
+        <div className="px-5">
+          <div className="flex h-16 items-center pr-1">
+            <span className="body1-medium text-gray-iron-950">내 커플 코드</span>
+            <div className="ml-auto flex items-center">
+              <span className="body2-medium text-gray-iron-950">{inviteCode}</span>
+              <button onClick={handleCopyInviteCode} className="ml-2">
+                <ClipBoardIcon className="h-4 w-4" />
+              </button>
+            </div>
           </div>
+
+          <hr className="h-px border-0 bg-gray-iron-100" />
+
+          <button onClick={handleConnectPartner} className="flex h-16 w-full items-center" disabled={isConnected}>
+            <span className={`body1-medium ${isConnected ? 'text-gray-iron-400' : 'text-gray-iron-950'}`}>
+              연인 코드로 연결하기
+            </span>
+          </button>
+
+          <hr className="h-px border-0 bg-gray-iron-100" />
+
+          <button onClick={handleDisconnectCouple} className="flex h-16 w-full items-center" disabled={!isConnected}>
+            <span className={`body1-medium ${isConnected ? 'text-gray-iron-950' : 'text-gray-iron-400'}`}>
+              커플 연결 끊기
+            </span>
+          </button>
         </div>
+      </Screen.Content>
 
-        {/* 구분선 */}
-        <hr className="h-px border-0 bg-gray-iron-100" />
-
-        {/* 연인 코드로 연결하기 */}
-        <button onClick={handleConnectPartner} className="flex h-16 w-full items-center" disabled={isConnected}>
-          <span className={`body1-medium ${isConnected ? 'text-gray-iron-400' : 'text-gray-iron-950'}`}>
-            연인 코드로 연결하기
-          </span>
-        </button>
-
-        {/* 구분선 */}
-        <hr className="h-px border-0 bg-gray-iron-100" />
-
-        {/* 커플 연결 끊기 */}
-        <button onClick={handleDisconnectCouple} className="flex h-16 w-full items-center" disabled={!isConnected}>
-          <span className={`body1-medium ${isConnected ? 'text-gray-iron-950' : 'text-gray-iron-400'}`}>
-            커플 연결 끊기
-          </span>
-        </button>
-      </div>
-
-      {/* 연인 코드 입력 바텀시트 */}
       <PartnerCodeSheet
         isOpen={isPartnerCodeSheetOpen}
         onOpenChange={setIsPartnerCodeSheetOpen}
         onSuccess={handleRefreshPage}
         onCoupleConnected={coupleConnectedModal}
       />
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/my-page/page.tsx
+++ b/apps/react/src/app/my-page/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { useAuth } from '@/features/auth'
 import { useMyPageMenu, ProfileSection, StatsSection, MenuList } from '@/features/profile'
 import { useTerms, TermsContentModal } from '@/features/term'
+import { Screen } from '@/shared/layout/screen'
 import termsService from '@/shared/services/terms.service'
 import { BottomNavigation } from '@/shared/ui/bottom-navigation'
 import { HomeHeaderBar } from '@/shared/ui/header-bar'
@@ -34,7 +35,7 @@ function MyPage() {
   const { menuItems } = useMyPageMenu(terms, handleShowTerms)
 
   return (
-    <div className="has-bottom-nav flex h-full flex-col bg-white">
+    <Screen>
       {/* 약관 모달 */}
       {selectedTermId !== null && selectedTermContent && selectedTermContent.title && selectedTermContent.details && (
         <TermsContentModal
@@ -45,24 +46,28 @@ function MyPage() {
       )}
 
       {/* 헤더 */}
-      <HomeHeaderBar title="마이페이지" />
+      <Screen.Header>
+        <HomeHeaderBar title="마이페이지" />
+      </Screen.Header>
 
       {/* 프로필 섹션 */}
-      <ProfileSection nickname={userInfo.nickname || ''} dDay={dDay} />
+      <Screen.Content className="bg-white">
+        <ProfileSection nickname={userInfo.nickname || ''} dDay={dDay} />
 
-      {/* 통계 박스 */}
-      <StatsSection
-        totalChatRoomCount={userInfo.totalChatRoomCount || 0}
-        totalCoupleQuestionCount={userInfo.totalCoupleQuestionCount || 0}
-      />
+        {/* 통계 박스 */}
+        <StatsSection
+          totalChatRoomCount={userInfo.totalChatRoomCount || 0}
+          totalCoupleQuestionCount={userInfo.totalCoupleQuestionCount || 0}
+        />
 
-      {/* 메뉴 리스트 */}
-      <div className="pb-[60px]">
-        <MenuList menuItems={menuItems} />
-      </div>
+        {/* 메뉴 리스트 */}
+        <div className="pb-[60px]">
+          <MenuList menuItems={menuItems} />
+        </div>
+      </Screen.Content>
 
       {/* 하단 네비게이션 */}
       <BottomNavigation />
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/my-page/profile/page.tsx
+++ b/apps/react/src/app/my-page/profile/page.tsx
@@ -6,6 +6,8 @@ import { usePartnerInfo } from '@/features/member'
 import { NicknameEditSheet, useProfileEdit } from '@/features/profile'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import { Badge } from '@/shared/ui/badge'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
@@ -30,6 +32,7 @@ function MenuItem({ label, onClick, rightElement }: MenuItemProps) {
 
 function ProfileEditPage() {
   const navigate = useNavigate()
+  const goBack = useGoBack()
   const profileEdit = useProfileEdit()
 
   // 커플 연동 상태 확인
@@ -66,31 +69,33 @@ function ProfileEditPage() {
   ]
 
   return (
-    <div className="h-full bg-white">
-      {/* 헤더 */}
-      <DetailHeaderBar title="내 정보" onBackClick={() => navigate({ to: '/my-page' })} />
+    <Screen>
+      <Screen.Header>
+        <DetailHeaderBar title="내 정보" onBackClick={goBack} />
+      </Screen.Header>
 
-      {/* 메뉴 리스트 */}
-      <div className="mt-0">
-        {menuItems.map((item, index) => (
-          <div key={item.label}>
-            {index > 0 && <hr className="h-px border-0 bg-gray-iron-100" />}
-            <MenuItem label={item.label} onClick={item.onClick} rightElement={item.rightElement} />
-          </div>
-        ))}
-      </div>
+      <Screen.Content className="bg-white">
+        <div className="mt-0">
+          {menuItems.map((item, index) => (
+            <div key={item.label}>
+              {index > 0 && <hr className="h-px border-0 bg-gray-iron-100" />}
+              <MenuItem label={item.label} onClick={item.onClick} rightElement={item.rightElement} />
+            </div>
+          ))}
+        </div>
 
-      {/* 바텀시트 */}
-      <NicknameEditSheet
-        isOpen={profileEdit.isNicknameSheetOpen}
-        onOpenChange={profileEdit.setNicknameSheetOpen}
-        onSave={wrapWithTracking(BUTTON_NAMES.SAVE_NICKNAME, CATEGORIES.PROFILE)}
-      />
-      <AnniversaryEditSheet
-        isOpen={profileEdit.isAnniversarySheetOpen}
-        onOpenChange={profileEdit.setAnniversarySheetOpen}
-        onSave={wrapWithTracking(BUTTON_NAMES.SAVE_ANNIVERSARY, CATEGORIES.PROFILE)}
-      />
-    </div>
+        {/* 바텀시트 */}
+        <NicknameEditSheet
+          isOpen={profileEdit.isNicknameSheetOpen}
+          onOpenChange={profileEdit.setNicknameSheetOpen}
+          onSave={wrapWithTracking(BUTTON_NAMES.SAVE_NICKNAME, CATEGORIES.PROFILE)}
+        />
+        <AnniversaryEditSheet
+          isOpen={profileEdit.isAnniversarySheetOpen}
+          onOpenChange={profileEdit.setAnniversarySheetOpen}
+          onSave={wrapWithTracking(BUTTON_NAMES.SAVE_ANNIVERSARY, CATEGORIES.PROFILE)}
+        />
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/onboarding/anniversary/page.tsx
+++ b/apps/react/src/app/onboarding/anniversary/page.tsx
@@ -6,6 +6,7 @@ import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboard
 import { TitleSection } from '@/features/onboarding/ui/title-section'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
@@ -34,37 +35,39 @@ function AnniversaryPage() {
   })
 
   return (
-    <div className="flex h-full w-full flex-col bg-white">
-      {/* 헤더 및 타이틀 */}
-      <DetailHeaderBar onBackClick={handlePrevious} />
-      <TitleSection
-        title={
-          <>
-            둘의 만남을 시작한 날짜는
-            <br />
-            언제인가요?
-          </>
-        }
-        description={'말모가 기념일을 기억하고 보여드릴게요!'}
-      />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={handlePrevious} />
+      </Screen.Header>
 
-      {/* 날짜 선택 */}
-      <div className="mt-[68px] px-5">
-        <DatePicker
-          state={state}
-          actions={{
-            handleYearScroll: actions.handleYearScroll,
-            handleMonthScroll: actions.handleMonthScroll,
-            handleDayScroll: actions.handleDayScroll,
-            handleDateChange: actions.handleDateChange,
-          }}
+      <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <TitleSection
+          title={
+            <>
+              둘의 만남을 시작한 날짜는
+              <br />
+              언제인가요?
+            </>
+          }
+          description={'말모가 기념일을 기억하고 보여드릴게요!'}
         />
-      </div>
 
-      {/* 다음 버튼 */}
-      <div className="mt-auto mb-5 px-5 pb-[var(--safe-bottom)]">
-        <Button text="다음" onClick={handleNext} />
-      </div>
-    </div>
+        <div className="mt-[68px] px-5">
+          <DatePicker
+            state={state}
+            actions={{
+              handleYearScroll: actions.handleYearScroll,
+              handleMonthScroll: actions.handleMonthScroll,
+              handleDayScroll: actions.handleDayScroll,
+              handleDateChange: actions.handleDateChange,
+            }}
+          />
+        </div>
+
+        <div className="mt-auto mb-5 px-5">
+          <Button text="다음" onClick={handleNext} />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/onboarding/my-code/page.tsx
+++ b/apps/react/src/app/onboarding/my-code/page.tsx
@@ -9,6 +9,7 @@ import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboard
 import { TitleSection } from '@/features/onboarding/ui/title-section'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import memberService from '@/shared/services/member.service'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 import { toast } from '@/shared/ui/toast'
@@ -59,68 +60,69 @@ function MyCodePage() {
   })
 
   return (
-    <div className="flex h-full w-full flex-col bg-white">
-      {/* 헤더 및 타이틀 */}
-      <DetailHeaderBar
-        onBackClick={wrapWithTracking(BUTTON_NAMES.BACK_MY_CODE, CATEGORIES.ONBOARDING, () => goToPreviousStep())}
-      />
-      <TitleSection
-        title={
-          <>
-            커플 연결하고
-            <br />
-            말모를 시작해보세요
-          </>
-        }
-        description="연인에게 커플 코드를 보내 커플연결을 해주세요!"
-      />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar
+          onBackClick={wrapWithTracking(BUTTON_NAMES.BACK_MY_CODE, CATEGORIES.ONBOARDING, () => goToPreviousStep())}
+        />
+      </Screen.Header>
 
-      {/* 러브레터 이미지 */}
-      <div className="mt-[68px] flex flex-col items-center">
-        <img src={loveLetter} alt="Love Letter" className="h-[100px] w-[100px]" />
-      </div>
+      <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <TitleSection
+          title={
+            <>
+              커플 연결하고
+              <br />
+              말모를 시작해보세요
+            </>
+          }
+          description="연인에게 커플 코드를 보내 커플연결을 해주세요!"
+        />
 
-      {/* 초대 코드 */}
-      <div className="mt-[24px] px-5">
-        <div className="rounded-[10px] bg-gray-neutral-100">
-          <div className="flex items-center justify-center px-[10px] py-[22px]">
-            <div className="flex flex-col items-center">
-              <p className="body3-medium text-gray-iron-500">나의 커플 코드</p>
-              <div className="mt-2 flex items-center">
-                {isLoadingInviteCode ? (
-                  <span className="heading1-semibold text-gray-iron-500">로딩 중...</span>
-                ) : (
-                  <span className="heading1-semibold text-gray-iron-950">{inviteCode}</span>
-                )}
-                <button onClick={handleCopyCode} className="ml-[10px]" disabled={isLoadingInviteCode}>
-                  <ClipBoardIcon className="h-5 w-5" />
-                </button>
+        <div className="mt-[68px] flex flex-col items-center">
+          <img src={loveLetter} alt="Love Letter" className="h-[100px] w-[100px]" />
+        </div>
+
+        <div className="mt-[24px] px-5">
+          <div className="rounded-[10px] bg-gray-neutral-100">
+            <div className="flex items-center justify-center px-[10px] py-[22px]">
+              <div className="flex flex-col items-center">
+                <p className="body3-medium text-gray-iron-500">나의 커플 코드</p>
+                <div className="mt-2 flex items-center">
+                  {isLoadingInviteCode ? (
+                    <span className="heading1-semibold text-gray-iron-500">로딩 중...</span>
+                  ) : (
+                    <span className="heading1-semibold text-gray-iron-950">{inviteCode}</span>
+                  )}
+                  <button onClick={handleCopyCode} className="ml-[10px]" disabled={isLoadingInviteCode}>
+                    <ClipBoardIcon className="h-5 w-5" />
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* 버튼 영역 */}
-      <div className="mt-auto mb-5 px-5 pb-[var(--safe-bottom)]">
-        <button
-          onClick={handleConnectWithCode}
-          className="body1-semibold flex h-[56px] w-full items-center justify-center rounded-[10px] border border-malmo-rasberry-500 text-malmo-rasberry-500"
-          disabled={isSubmitting}
-        >
-          연인 코드로 연결하기
-        </button>
-
-        <div className="mt-[20px] flex justify-center">
+        <div className="mt-auto mb-5 px-5">
           <button
-            onClick={handleSkip}
-            className="body3-medium text-gray-iron-400 underline decoration-1"
+            onClick={handleConnectWithCode}
+            className="body1-semibold flex h-[56px] w-full items-center justify-center rounded-[10px] border border-malmo-rasberry-500 text-malmo-rasberry-500"
             disabled={isSubmitting}
           >
-            일단 혼자 사용해볼게요
+            연인 코드로 연결하기
           </button>
+
+          <div className="mt-[20px] flex justify-center">
+            <button
+              onClick={handleSkip}
+              className="body3-medium text-gray-iron-400 underline decoration-1"
+              disabled={isSubmitting}
+            >
+              일단 혼자 사용해볼게요
+            </button>
+          </div>
         </div>
-      </div>
-    </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/onboarding/nickname/page.tsx
+++ b/apps/react/src/app/onboarding/nickname/page.tsx
@@ -7,6 +7,7 @@ import { useNicknameInput, NicknameInput } from '@/features/profile'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useKeyboardSheetMotion } from '@/shared/hooks/use-keyboard-motion'
+import { Screen } from '@/shared/layout/screen'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
@@ -37,34 +38,36 @@ function NicknamePage() {
   })
 
   return (
-    <div className="flex h-full w-full flex-col bg-white">
-      {/* 헤더 및 타이틀 */}
-      <DetailHeaderBar onBackClick={handlePrevious} />
-      <TitleSection
-        title={
-          <>
-            만나서 반가워요!
-            <br />
-            어떻게 불러드릴까요?
-          </>
-        }
-      />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={handlePrevious} />
+      </Screen.Header>
 
-      {/* 닉네임 입력 */}
-      <div className="mt-[68px] px-5">
-        <NicknameInput
-          value={nickname}
-          onChange={handleNicknameChange}
-          maxLength={maxLength}
-          placeholder="닉네임을 입력해주세요"
-          className="body2-medium"
+      <Screen.Content className="flex flex-1 flex-col bg-white">
+        <TitleSection
+          title={
+            <>
+              만나서 반가워요!
+              <br />
+              어떻게 불러드릴까요?
+            </>
+          }
         />
-      </div>
 
-      {/* 다음 버튼 */}
-      <div className="mt-auto mb-5 px-5" style={keyboardBottom}>
-        <Button text="다음" onClick={handleNext} disabled={!isValid} />
-      </div>
-    </div>
+        <div className="mt-[68px] px-5">
+          <NicknameInput
+            value={nickname}
+            onChange={handleNicknameChange}
+            maxLength={maxLength}
+            placeholder="닉네임을 입력해주세요"
+            className="body2-medium"
+          />
+        </div>
+
+        <div className="mt-auto mb-5 px-5" style={keyboardBottom}>
+          <Button text="다음" onClick={handleNext} disabled={!isValid} />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/onboarding/partner-code/page.tsx
+++ b/apps/react/src/app/onboarding/partner-code/page.tsx
@@ -8,6 +8,7 @@ import { TitleSection } from '@/features/onboarding/ui/title-section'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useKeyboardSheetMotion } from '@/shared/hooks/use-keyboard-motion'
+import { Screen } from '@/shared/layout/screen'
 import coupleService from '@/shared/services/couple.service'
 import { Button, Input } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -51,38 +52,40 @@ function PartnerCodePage() {
   })
 
   return (
-    <div className="flex h-full w-full flex-col bg-white">
-      {/* 헤더 및 타이틀 */}
-      <DetailHeaderBar onBackClick={handlePrevious} />
-      <TitleSection
-        title={
-          <>
-            연인의 커플 코드를
-            <br />
-            입력해주세요
-          </>
-        }
-      />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={handlePrevious} />
+      </Screen.Header>
 
-      {/* 코드 입력 */}
-      <div className="mt-[68px] px-5">
-        <Input
-          type="text"
-          value={partnerCode}
-          onChange={(e) => setPartnerCode(e.target.value)}
-          placeholder="코드를 입력해주세요"
-          maxLength={7}
+      <Screen.Content className="flex flex-1 flex-col bg-white">
+        <TitleSection
+          title={
+            <>
+              연인의 커플 코드를
+              <br />
+              입력해주세요
+            </>
+          }
         />
-      </div>
 
-      {/* 다음 버튼 */}
-      <div className="mt-auto mb-5 px-5" style={keyboardBottom}>
-        <Button
-          text="연결하기"
-          onClick={handleNext}
-          disabled={connectCoupleMutation.isPending || !partnerCode.trim()}
-        />
-      </div>
-    </div>
+        <div className="mt-[68px] px-5">
+          <Input
+            type="text"
+            value={partnerCode}
+            onChange={(e) => setPartnerCode(e.target.value)}
+            placeholder="코드를 입력해주세요"
+            maxLength={7}
+          />
+        </div>
+
+        <div className="mt-auto mb-5 px-5" style={keyboardBottom}>
+          <Button
+            text="연결하기"
+            onClick={handleNext}
+            disabled={connectCoupleMutation.isPending || !partnerCode.trim()}
+          />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/onboarding/terms/page.tsx
+++ b/apps/react/src/app/onboarding/terms/page.tsx
@@ -7,6 +7,7 @@ import { TitleSection } from '@/features/onboarding/ui/title-section'
 import { useTerms, TermsAgreementList, TermsContentModal } from '@/features/term'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import termsService from '@/shared/services/terms.service'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -51,8 +52,7 @@ function TermsPage() {
   })
 
   return (
-    <div className="flex h-full w-full flex-col bg-white">
-      {/* 약관 전체화면 */}
+    <Screen>
       {selectedTermId !== null && selectedTermContent && (
         <TermsContentModal
           title={selectedTermContent.title || ''}
@@ -61,29 +61,31 @@ function TermsPage() {
         />
       )}
 
-      {/* 헤더 및 타이틀 */}
-      <DetailHeaderBar onBackClick={handleBack} />
-      <TitleSection
-        title={
-          <p>
-            서비스 이용 약관에 <br /> 동의해주세요
-          </p>
-        }
-      />
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={handleBack} showBackButton={false} />
+      </Screen.Header>
 
-      {/* 약관 동의 섹션 */}
-      <TermsAgreementList
-        terms={terms}
-        agreements={agreements}
-        onAllAgreementChange={handleAllAgreements}
-        onAgreementChange={handleAgreement}
-        onShowTerms={handleShowTerms}
-      />
+      <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <TitleSection
+          title={
+            <p>
+              서비스 이용 약관에 <br /> 동의해주세요
+            </p>
+          }
+        />
 
-      {/* 다음 버튼 */}
-      <div className="mt-auto mb-5 px-5 pb-[var(--safe-bottom)]">
-        <Button text="다음" disabled={!isAllRequiredChecked} onClick={handleNext} />
-      </div>
-    </div>
+        <TermsAgreementList
+          terms={terms}
+          agreements={agreements}
+          onAllAgreementChange={handleAllAgreements}
+          onAgreementChange={handleAgreement}
+          onShowTerms={handleShowTerms}
+        />
+
+        <div className="mt-auto mb-5 px-5">
+          <Button text="다음" disabled={!isAllRequiredChecked} onClick={handleNext} />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/page.tsx
+++ b/apps/react/src/app/page.tsx
@@ -14,6 +14,7 @@ import { useAppNotifications } from '@/features/notification'
 import { TodayQuestionSection, useTodayQuestion } from '@/features/question'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import chatService from '@/shared/services/chat.service'
 import memberService from '@/shared/services/member.service'
 import questionService from '@/shared/services/question.service'
@@ -85,20 +86,18 @@ function HomePage() {
   })
 
   return (
-    <div className="has-bottom-nav flex h-full flex-col bg-white pt-[60px]">
-      {/* 헤더 */}
-      <header className="fixed top-[var(--safe-top)] flex h-[60px] w-full items-center justify-between bg-white px-5">
-        <img src={malmoLogo} alt="말모 로고" className="h-8 w-[94px]" />
-
-        {/* D-day */}
-        <div className="flex h-8 items-center rounded-[30px] border border-gray-iron-200 px-4 py-[5px]">
-          <HeartIcon className="h-4 w-4" />
-          <span className="body2-semibold ml-[9px] text-gray-iron-950">D+{dDay}</span>
+    <Screen>
+      <Screen.Header behavior="overlay" className="bg-white">
+        <div className="pt-safe-top flex h-[60px] items-center justify-between px-5">
+          <img src={malmoLogo} alt="말모 로고" className="h-8 w-[94px]" />
+          <div className="flex h-8 items-center rounded-[30px] border border-gray-iron-200 px-4 py-[5px]">
+            <HeartIcon className="h-4 w-4" />
+            <span className="body2-semibold ml-[9px] text-gray-iron-950">D+{dDay}</span>
+          </div>
         </div>
-      </header>
+      </Screen.Header>
 
-      {/* 메인 컨텐츠  */}
-      <div className="mt-3 flex-1 px-5">
+      <Screen.Content className="no-bounce-scroll has-bottom-nav pt-safe-top flex-1 px-5">
         {/* 연애 고민 상담 섹션 */}
         <ChatEntryCard isChatActive={isChatActive} />
 
@@ -118,10 +117,10 @@ function HomePage() {
           partnerAttachmentType={partnerAttachmentType}
           isPartnerConnected={isPartnerConnected}
         />
-      </div>
+      </Screen.Content>
 
       {/* 하단 네비게이션 */}
       <BottomNavigation />
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/partner-status/page.tsx
+++ b/apps/react/src/app/partner-status/page.tsx
@@ -4,8 +4,9 @@ import { z } from 'zod'
 import momoEmptyStateImage from '@/assets/images/momo-empty-state.png'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import { Button } from '@/shared/ui/button'
-// 상태별 이미지 import
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
 // 쿼리 파라미터 검증 스키마
@@ -20,50 +21,51 @@ export const Route = createFileRoute('/partner-status/')({
 
 function PartnerStatusPage() {
   const navigate = useNavigate()
+  const goBack = useGoBack()
   const { type } = useSearch({ from: '/partner-status/' })
 
   const handleGoToHome = () => {
-    navigate({ to: '/' })
+    goBack()
   }
 
   const handleGoToMyPage = wrapWithTracking(BUTTON_NAMES.GO_MYPAGE, CATEGORIES.MAIN, () => navigate({ to: '/my-page' }))
 
   return (
-    <div className="flex h-full w-full flex-col bg-white pb-[var(--safe-bottom)]">
-      {/* 헤더 */}
-      <DetailHeaderBar onBackClick={handleGoToHome} />
+    <Screen>
+      <Screen.Header>
+        <DetailHeaderBar onBackClick={handleGoToHome} />
+      </Screen.Header>
 
-      {/* 메인 콘텐츠 */}
-      <div className="flex flex-1 -translate-y-[80px] flex-col items-center justify-center px-6">
-        {/* 이미지 */}
-        <div className="h-[236px] w-[320px]">
-          <img src={momoEmptyStateImage} className="h-full w-full object-contain" />
+      <Screen.Content className="no-bounce-scroll flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <div className="flex flex-1 -translate-y-[80px] flex-col items-center justify-center px-6">
+          <div className="h-[236px] w-[320px]">
+            <img src={momoEmptyStateImage} className="h-full w-full object-contain" />
+          </div>
+
+          {type === 'not-connected' ? (
+            <h1 className="heading1-bold mt-6 text-center text-gray-iron-950">아직 커플 연동하기 전이에요!</h1>
+          ) : (
+            <h1 className="heading1-bold mt-6 text-center text-gray-iron-950">아직 애착유형 검사를 하기 전이에요!</h1>
+          )}
+
+          {type === 'not-connected' ? (
+            <p className="body2-medium mt-1 text-center">
+              <span className="text-malmo-rasberry-500">마이페이지 &gt; 프로필 &gt; 커플 연동 관리</span>
+              <span className="text-gray-iron-950">에서 초대가 가능해요</span>
+            </p>
+          ) : (
+            <p className="body2-medium mt-1 text-center text-gray-iron-500">
+              연인이 검사를 완료하면 결과를 볼 수 있어요
+            </p>
+          )}
         </div>
 
-        {/* 타이틀 */}
         {type === 'not-connected' ? (
-          <h1 className="heading1-bold mt-6 text-center text-gray-iron-950">아직 커플 연동하기 전이에요!</h1>
-        ) : (
-          <h1 className="heading1-bold mt-6 text-center text-gray-iron-950">아직 애착유형 검사를 하기 전이에요!</h1>
-        )}
-
-        {/* 설명 */}
-        {type === 'not-connected' ? (
-          <p className="body2-medium mt-1 text-center">
-            <span className="text-malmo-rasberry-500">마이페이지 &gt; 프로필 &gt; 커플 연동 관리</span>
-            <span className="text-gray-iron-950">에서 초대가 가능해요</span>
-          </p>
-        ) : (
-          <p className="body2-medium mt-1 text-center text-gray-iron-500">연인이 검사를 완료하면 결과를 볼 수 있어요</p>
-        )}
-      </div>
-
-      {/* 하단 버튼 */}
-      {type === 'not-connected' && (
-        <div className="mb-5 px-6">
-          <Button text="마이페이지로 이동하기" onClick={handleGoToMyPage} />
-        </div>
-      )}
-    </div>
+          <div className="mb-5 px-6">
+            <Button text="마이페이지로 이동하기" onClick={handleGoToMyPage} />
+          </div>
+        ) : null}
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/question/page.tsx
+++ b/apps/react/src/app/question/page.tsx
@@ -9,6 +9,7 @@ import { TodayQuestionSection } from '@/features/question'
 import CalendarItem from '@/features/question/ui/calendar-item'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import { cn } from '@/shared/lib/cn'
 import questionService from '@/shared/services/question.service'
 import { Badge, BottomNavigation } from '@/shared/ui'
@@ -61,10 +62,12 @@ function RouteComponent() {
   const maxPage = Math.floor((data.level - 1) / 30)
 
   return (
-    <div className="has-bottom-nav flex h-full flex-col bg-gray-neutral-100">
-      <HomeHeaderBar title="마음도감" />
+    <Screen>
+      <Screen.Header>
+        <HomeHeaderBar title="마음도감" />
+      </Screen.Header>
 
-      <section className="overflow-y-auto overscroll-y-none bg-white">
+      <Screen.Content className="has-bottom-nav flex-1 overflow-y-auto overscroll-y-none bg-gray-neutral-100">
         <div className="bg-white pt-3 pb-7">
           <div className="mb-4 flex items-center justify-between pr-5 pl-[14px]">
             <div className="flex items-center gap-1 py-[2px]">
@@ -146,7 +149,7 @@ function RouteComponent() {
           </div>
         </div>
 
-        <div className="flex-1 bg-gray-neutral-100 px-5 pt-5 pb-12">
+        <div className="flex-1 px-5 pt-5">
           <Link
             to={selectedQuestion.meAnswered ? '/question/see-answer' : '/question/write-answer'}
             search={{ coupleQuestionId: selectedQuestion?.coupleQuestionId || 0, isEdit: false }}
@@ -159,9 +162,9 @@ function RouteComponent() {
             <TodayQuestionSection todayQuestion={selectedQuestion} level={selectedQuestion.level} />
           </Link>
         </div>
-      </section>
+      </Screen.Content>
 
       <BottomNavigation />
-    </div>
+    </Screen>
   )
 }

--- a/apps/react/src/app/question/see-answer/page.tsx
+++ b/apps/react/src/app/question/see-answer/page.tsx
@@ -10,6 +10,7 @@ import { QuestionHeader } from '@/features/question/ui/question-header'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import bridge from '@/shared/bridge'
+import { Screen } from '@/shared/layout/screen'
 import { cn } from '@/shared/lib/cn'
 import questionService from '@/shared/services/question.service'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -39,10 +40,12 @@ function RouteComponent() {
   const { data } = useQuery(questionService.questionDetailQuery(coupleQuestionId))
 
   return (
-    <div className="flex h-full flex-col">
-      <DetailHeaderBar title="답변 보기" className="border-b-[1px] border-gray-iron-100" />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar title="답변 보기" className="border-b border-gray-iron-100" />
+      </Screen.Header>
 
-      <div className="flex-1">
+      <Screen.Content className="flex flex-1 flex-col bg-white">
         <QuestionHeader data={data} />
 
         <div className="mb-15 px-5">
@@ -115,7 +118,7 @@ function RouteComponent() {
             </p>
           </div>
         </div>
-      </div>
-    </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/app/question/write-answer/page.tsx
+++ b/apps/react/src/app/question/write-answer/page.tsx
@@ -8,6 +8,7 @@ import { QuestionHeader } from '@/features/question/ui/question-header'
 import CustomTextarea from '@/features/question/ui/text-area'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
 import questionService from '@/shared/services/question.service'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
@@ -48,16 +49,20 @@ function RouteComponent() {
   )
 
   return (
-    <div className="flex h-full flex-col pb-[var(--safe-bottom)]">
-      <DetailHeaderBar title="답변 작성" className="border-b-[1px] border-gray-iron-100" onBackClick={handleBack} />
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar title="답변 작성" className="border-b border-gray-iron-100" onBackClick={handleBack} />
+      </Screen.Header>
 
-      <QuestionHeader data={data} />
+      <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <QuestionHeader data={data} />
 
-      <CustomTextarea value={answer} onChange={(e) => setAnswer(e.target.value)} maxLength={MAX_LENGTH} />
+        <CustomTextarea value={answer} onChange={(e) => setAnswer(e.target.value)} maxLength={MAX_LENGTH} />
 
-      <div className="p-5">
-        <Button text="저장하기" onClick={handleSave} disabled={!answer.trim()} />
-      </div>
-    </div>
+        <div className="mt-auto p-5">
+          <Button text="저장하기" onClick={handleSave} disabled={!answer.trim()} />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/features/attachment/hooks/use-attachment-questions.ts
+++ b/apps/react/src/features/attachment/hooks/use-attachment-questions.ts
@@ -1,8 +1,9 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { useNavigate, useRouter } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
 import { useState, useEffect, useRef } from 'react'
 
 import { useAuth } from '@/features/auth'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import loveTypeService from '@/shared/services/love-type.service'
 import memberService from '@/shared/services/member.service'
 import { toast } from '@/shared/ui/toast'
@@ -60,7 +61,7 @@ export interface UseAttachmentQuestionsResult {
 
 export function useAttachmentQuestions(): UseAttachmentQuestionsResult {
   const navigate = useNavigate()
-  const router = useRouter()
+  const goBack = useGoBack()
   const auth = useAuth()
 
   // 질문 목록 상태
@@ -131,7 +132,7 @@ export function useAttachmentQuestions(): UseAttachmentQuestionsResult {
       setCurrentPage(currentPage - 1)
       scrollToFirstQuestion(questionRefs)
     } else {
-      router.history.back()
+      goBack()
     }
   }
 

--- a/apps/react/src/features/attachment/ui/main/attachment-test-intro.tsx
+++ b/apps/react/src/features/attachment/ui/main/attachment-test-intro.tsx
@@ -1,24 +1,12 @@
-import { useNavigate } from '@tanstack/react-router'
-
 import TestStartImage from '@/assets/images/test-start.png'
-import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
 interface AttachmentTestIntroProps {
   nickname: string
-  from?: string
 }
 
-export function AttachmentTestIntro({ nickname, from }: AttachmentTestIntroProps) {
-  const navigate = useNavigate()
-
-  const handleGoToHome = () => {
-    navigate({ to: from || '/' })
-  }
-
+export function AttachmentTestIntro({ nickname }: AttachmentTestIntroProps) {
   return (
     <div className="bg-malmo-rasberry-25 pt-[50px]">
-      <DetailHeaderBar onBackClick={handleGoToHome} className="fixed top-[var(--safe-top)] bg-malmo-rasberry-25" />
-
       {/* 테스트 시작 이미지 */}
       <div className="mt-[36px] flex justify-center overflow-hidden">
         <img src={TestStartImage} alt="애착유형 테스트 시작" className="w-[440px] object-cover" />

--- a/apps/react/src/features/attachment/ui/result/attachment-result-content.tsx
+++ b/apps/react/src/features/attachment/ui/result/attachment-result-content.tsx
@@ -10,6 +10,8 @@ import { ResultDetailBox } from '@/features/attachment/ui/result/result-detail-b
 import { ResultScoreBox } from '@/features/attachment/ui/result/result-score-box'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { Screen } from '@/shared/layout/screen'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
@@ -27,6 +29,7 @@ interface AttachmentResultContentProps {
 
 export function AttachmentResultContent({ userInfo, type }: AttachmentResultContentProps) {
   const navigate = useNavigate()
+  const goBack = useGoBack()
   const isMyResult = type === 'my'
 
   // 결과 데이터 확인
@@ -40,7 +43,7 @@ export function AttachmentResultContent({ userInfo, type }: AttachmentResultCont
           <Button
             text="홈으로 이동"
             onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.ATTACHMENT, () =>
-              navigate({ to: '/' })
+              navigate({ to: '/', replace: true })
             )}
           />
         </div>
@@ -57,9 +60,7 @@ export function AttachmentResultContent({ userInfo, type }: AttachmentResultCont
           <p className="mb-4 text-red-500">애착 유형 데이터를 찾을 수 없습니다.</p>
           <Button
             text="홈으로 이동"
-            onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.ATTACHMENT, () =>
-              navigate({ to: '/' })
-            )}
+            onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.ATTACHMENT, () => goBack())}
           />
         </div>
       </div>
@@ -67,87 +68,88 @@ export function AttachmentResultContent({ userInfo, type }: AttachmentResultCont
   }
 
   const handleClose = () => {
-    navigate({ to: '/', resetScroll: true })
+    goBack()
   }
 
   return (
-    <div className="flex h-full w-full flex-col bg-white pt-[50px]">
-      {/* 헤더 네비게이션 */}
-      <DetailHeaderBar
-        showBackButton={false}
-        right={
-          <button onClick={handleClose}>
-            <X className="h-6 w-6 text-gray-iron-950" />
-          </button>
-        }
-        className="fixed top-[var(--safe-top)]"
-      />
-
-      {/* 캐릭터 정보 섹션 */}
-      <div className="mt-[4px] flex flex-col items-center px-[20px]">
-        {/* 캐릭터 이미지 */}
-        <img
-          src={attachmentData.characterImage}
-          alt={attachmentData.character}
-          className="h-[240px] w-[260px] object-contain"
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar
+          showBackButton={false}
+          right={
+            <button onClick={handleClose}>
+              <X className="h-6 w-6 text-gray-iron-950" />
+            </button>
+          }
         />
+      </Screen.Header>
 
-        {/* 애착유형 텍스트 */}
-        <div className="mt-[10px] text-center">
-          <h1 className="heading1-semibold text-gray-iron-950">
-            {isMyResult
-              ? `${userInfo.nickname || '사용자'}님의 애착유형은`
-              : `${userInfo.nickname || '연인'}님의 애착유형은`}
-          </h1>
-          <h2 className="title2-bold" style={{ color: attachmentData.color }}>
-            {attachmentData.character}
-          </h2>
+      <Screen.Content className="flex flex-col bg-white">
+        <div className="mt-[4px] flex flex-col items-center px-[20px]">
+          {/* 캐릭터 이미지 */}
+          <img
+            src={attachmentData.characterImage}
+            alt={attachmentData.character}
+            className="h-[240px] w-[260px] object-contain"
+          />
+
+          {/* 애착유형 텍스트 */}
+          <div className="mt-[10px] text-center">
+            <h1 className="heading1-semibold text-gray-iron-950">
+              {isMyResult
+                ? `${userInfo.nickname || '사용자'}님의 애착유형은`
+                : `${userInfo.nickname || '연인'}님의 애착유형은`}
+            </h1>
+            <h2 className="title2-bold" style={{ color: attachmentData.color }}>
+              {attachmentData.character}
+            </h2>
+          </div>
         </div>
-      </div>
 
-      {/* 결과 정보 섹션 */}
-      <div className="mt-[52px] px-[20px]">
-        {/* 점수 박스 */}
-        <ResultScoreBox anxietyRate={userInfo.anxietyRate || 0} avoidanceRate={userInfo.avoidanceRate || 0} />
+        {/* 결과 정보 섹션 */}
+        <div className="mt-[52px] px-[20px]">
+          {/* 점수 박스 */}
+          <ResultScoreBox anxietyRate={userInfo.anxietyRate || 0} avoidanceRate={userInfo.avoidanceRate || 0} />
 
-        {/* 상세 정보 박스 */}
-        <ResultDetailBox attachmentData={attachmentData} />
-      </div>
+          {/* 상세 정보 박스 */}
+          <ResultDetailBox attachmentData={attachmentData} />
+        </div>
 
-      {/* 결과 태도 섹션 */}
-      <div className="mt-[52px] px-[20px]">
-        {/* 관계에 대한 태도 */}
-        <ResultAttitudeSection
-          icon={RelationshipIcon}
-          title="관계에 대한 태도"
-          color={attachmentData.color}
-          items={attachmentData.relationshipAttitudes}
-        />
+        {/* 결과 태도 섹션 */}
+        <div className="mt-[52px] px-[20px]">
+          {/* 관계에 대한 태도 */}
+          <ResultAttitudeSection
+            icon={RelationshipIcon}
+            title="관계에 대한 태도"
+            color={attachmentData.color}
+            items={attachmentData.relationshipAttitudes}
+          />
 
-        {/* 갈등해결 태도 */}
-        <ResultAttitudeSection
-          icon={ConflictIcon}
-          title="갈등 해결 태도"
-          color="#1B1B1B"
-          items={attachmentData.conflictSolvingAttitudes}
-        />
+          {/* 갈등해결 태도 */}
+          <ResultAttitudeSection
+            icon={ConflictIcon}
+            title="갈등 해결 태도"
+            color="#1B1B1B"
+            items={attachmentData.conflictSolvingAttitudes}
+          />
 
-        {/* 정서적인 표현 */}
-        <ResultAttitudeSection
-          icon={EmotionIcon}
-          title="정서적인 표현"
-          color={attachmentData.color}
-          items={attachmentData.emotionalExpressions}
-        />
-      </div>
+          {/* 정서적인 표현 */}
+          <ResultAttitudeSection
+            icon={EmotionIcon}
+            title="정서적인 표현"
+            color={attachmentData.color}
+            items={attachmentData.emotionalExpressions}
+          />
+        </div>
 
-      {/* 바텀 버튼 */}
-      <div className="px-5 pb-[calc(var(--safe-bottom)_+_20px)]">
-        <Button
-          text="홈으로 이동하기"
-          onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.ATTACHMENT, handleClose)}
-        />
-      </div>
-    </div>
+        {/* 바텀 버튼 */}
+        <div className="px-5 pb-[calc(var(--safe-bottom)_+_20px)]">
+          <Button
+            text="홈으로 이동하기"
+            onClick={wrapWithTracking(BUTTON_NAMES.GO_HOME_FROM_RESULT, CATEGORIES.ATTACHMENT, handleClose)}
+          />
+        </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/features/chat/hooks/use-chatting-modal.tsx
+++ b/apps/react/src/features/chat/hooks/use-chatting-modal.tsx
@@ -1,12 +1,13 @@
 import { ChatRoomStateDataChatRoomStateEnum } from '@data/user-api-axios/api'
 import { useQueryClient } from '@tanstack/react-query'
-import { useLocation, useRouter } from '@tanstack/react-router'
+import { useLocation, useNavigate } from '@tanstack/react-router'
 import { ChevronRightIcon } from 'lucide-react'
 import { useState, useEffect } from 'react'
 
 import { useAuth } from '@/features/auth'
 import bridge from '@/shared/bridge'
 import { useAlertDialog } from '@/shared/hooks/use-alert-dialog'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import chatService from '@/shared/services/chat.service'
 import { Button } from '@/shared/ui'
 
@@ -19,7 +20,8 @@ export interface UseChattingModalReturn {
 
 export function useChattingModal(chatStatus?: ChatRoomStateDataChatRoomStateEnum): UseChattingModalReturn {
   const alertDialog = useAlertDialog()
-  const router = useRouter()
+  const navigate = useNavigate()
+  const goBack = useGoBack()
   const queryClient = useQueryClient()
   const { pathname } = useLocation()
   const auth = useAuth()
@@ -65,11 +67,11 @@ export function useChattingModal(chatStatus?: ChatRoomStateDataChatRoomStateEnum
       confirmText: '검사하러 가기',
       onCancel: () => {
         alertDialog.close()
-        router.history.back()
+        goBack()
       },
       onConfirm: () => {
         alertDialog.close()
-        router.navigate({ to: '/attachment-test' })
+        navigate({ to: '/attachment-test' })
       },
     })
   }
@@ -93,7 +95,7 @@ export function useChattingModal(chatStatus?: ChatRoomStateDataChatRoomStateEnum
       onCancel: () => {
         queryClient.invalidateQueries({ queryKey: chatService.chatRoomStatusQuery().queryKey })
         alertDialog.close()
-        router.history.back()
+        goBack()
       },
     })
   }

--- a/apps/react/src/features/history/hooks/use-chat-select.tsx
+++ b/apps/react/src/features/history/hooks/use-chat-select.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 
 import { wrapWithTracking } from '@/shared/analytics'
@@ -8,6 +8,7 @@ import { useHistoryModal } from './use-history-modal'
 
 export const useChatSelect = () => {
   const historyModal = useHistoryModal()
+  const navigate = useNavigate()
   const [selectedIds, setSelectedIds] = useState<number[]>([])
 
   const handleToggleSelect = wrapWithTracking(BUTTON_NAMES.SELECT_ITEM, CATEGORIES.MAIN, (id?: number) => {
@@ -20,9 +21,15 @@ export const useChatSelect = () => {
   )
 
   const backButton = () => (
-    <Link to="/history" replace onClick={wrapWithTracking(BUTTON_NAMES.BACK_DELETE, CATEGORIES.MAIN, () => {})}>
-      <p className="body2-medium text-gray-iron-900">완료</p>
-    </Link>
+    <button
+      type="button"
+      className="body2-medium text-gray-iron-900"
+      onClick={wrapWithTracking(BUTTON_NAMES.BACK_DELETE, CATEGORIES.MAIN, () =>
+        navigate({ to: '/history', replace: true, state: { skipTransition: true } })
+      )}
+    >
+      완료
+    </button>
   )
 
   return {

--- a/apps/react/src/features/history/hooks/use-history-modal.tsx
+++ b/apps/react/src/features/history/hooks/use-history-modal.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient, useMutation } from '@tanstack/react-query'
-import { useRouter } from '@tanstack/react-router'
 
 import { useAlertDialog } from '@/shared/hooks/use-alert-dialog'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import historyService from '@/shared/services/history.service'
 import { queryKeys } from '@/shared/services/query-keys'
 
@@ -12,7 +12,7 @@ export interface UseHistoryModalReturn {
 
 export function useHistoryModal(): UseHistoryModalReturn {
   const alertDialog = useAlertDialog()
-  const router = useRouter()
+  const goBack = useGoBack()
   const queryClient = useQueryClient()
 
   const deleteHistoryMutation = useMutation({
@@ -38,7 +38,7 @@ export function useHistoryModal(): UseHistoryModalReturn {
       onCancel: async () => {
         alertDialog.close()
         await deleteHistoryMutation.mutateAsync([id])
-        router.history.back()
+        goBack()
       },
     })
   }

--- a/apps/react/src/features/onboarding/hooks/use-onboarding-navigation.ts
+++ b/apps/react/src/features/onboarding/hooks/use-onboarding-navigation.ts
@@ -47,7 +47,7 @@ export function useOnboardingNavigation() {
 
   // 홈으로 이동
   const goToHome = () => {
-    navigate({ to: '/' })
+    navigate({ to: '/', replace: true })
   }
 
   return {

--- a/apps/react/src/features/profile/hooks/use-profile-modal.tsx
+++ b/apps/react/src/features/profile/hooks/use-profile-modal.tsx
@@ -159,7 +159,7 @@ export function useProfileModal(): UseProfileModalReturn {
       },
       onCancel: async () => {
         await refreshUserInfo()
-        navigate({ to: '/my-page' })
+        navigate({ to: '/my-page', replace: true, state: { skipTransition: true } })
         router.invalidate()
         onCancel?.()
       },

--- a/apps/react/src/features/question/hooks/use-question-modal.tsx
+++ b/apps/react/src/features/question/hooks/use-question-modal.tsx
@@ -1,7 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
 
 import { useAlertDialog } from '@/shared/hooks/use-alert-dialog'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 import questionService from '@/shared/services/question.service'
 
 export interface UseQuestionModalReturn {
@@ -12,7 +13,8 @@ export interface UseQuestionModalReturn {
 export function useQuestionModal(): UseQuestionModalReturn {
   const alertDialog = useAlertDialog()
   const queryClient = useQueryClient()
-  const router = useRouter()
+  const navigate = useNavigate()
+  const goBack = useGoBack()
 
   const submitAnswerMutation = useMutation(questionService.submitAnswerMutation())
   const updateAnswerMutation = useMutation(questionService.updateAnswerMutation())
@@ -42,7 +44,7 @@ export function useQuestionModal(): UseQuestionModalReturn {
               }
               await queryClient.invalidateQueries({ queryKey: questionService.todayQuestionQuery().queryKey })
 
-              router.navigate({
+              navigate({
                 to: '/question/see-answer',
                 search: { coupleQuestionId: data?.coupleQuestionId },
                 replace: true,
@@ -68,7 +70,7 @@ export function useQuestionModal(): UseQuestionModalReturn {
       confirmText: '이어서 작성하기',
       onCancel: () => {
         alertDialog.close()
-        router.history.back()
+        goBack()
       },
     })
   }

--- a/apps/react/src/features/term/ui/terms-content-modal.tsx
+++ b/apps/react/src/features/term/ui/terms-content-modal.tsx
@@ -1,5 +1,6 @@
 import { TermsDetailsResponseDataTypeEnum } from '@data/user-api-axios/api'
 
+import { Screen } from '@/shared/layout/screen'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
 import { TermDetail } from '../models/types'
@@ -30,15 +31,20 @@ export function TermsContentModal({ title, details, onClose }: TermsContentModal
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-white pt-[var(--safe-top)]">
-      <DetailHeaderBar onBackClick={onClose} />
-      <div className="flex-1 overflow-y-auto px-5">
-        <h2 className="title1-bold mt-10 pb-[26px] text-gray-iron-950">{title}</h2>
+    <div className="fixed inset-0 z-50 bg-white">
+      <Screen>
+        <Screen.Header behavior="overlay">
+          <DetailHeaderBar onBackClick={onClose} />
+        </Screen.Header>
 
-        <div className="pb-[var(--safe-bottom)] text-gray-iron-950">
-          {details?.map((detail, index) => <div key={index}>{renderDetailContent(detail)}</div>)}
-        </div>
-      </div>
+        <Screen.Content className="flex flex-1 flex-col overflow-y-auto px-5 pb-[var(--safe-bottom)]">
+          <h2 className="title1-bold mt-10 pb-[26px] text-gray-iron-950">{title}</h2>
+
+          <div className="text-gray-iron-950">
+            {details?.map((detail, index) => <div key={index}>{renderDetailContent(detail)}</div>)}
+          </div>
+        </Screen.Content>
+      </Screen>
     </div>
   )
 }

--- a/apps/react/src/router.tsx
+++ b/apps/react/src/router.tsx
@@ -23,7 +23,13 @@ export function createRouter() {
     scrollToTopSelectors: ['.main-scrollable'],
     defaultStructuralSharing: true,
     defaultNotFoundComponent: () => <NotFound />,
-    defaultErrorComponent: ({ error }) => <RouterError error={error} />,
+    defaultErrorComponent: ({ error }) => (
+      <div className="main-scrollable app-safe flex h-screen w-full flex-col overflow-hidden bg-white">
+        <main className="relative mx-auto flex min-h-0 w-full max-w-[600px] flex-1 flex-col">
+          <RouterError error={error} />
+        </main>
+      </div>
+    ),
     context: {
       auth: {} as never,
       queryClient,

--- a/apps/react/src/shared/hooks/use-alert-dialog.ts
+++ b/apps/react/src/shared/hooks/use-alert-dialog.ts
@@ -1,9 +1,27 @@
-import { use } from 'react'
+import { use, useCallback, useMemo } from 'react'
+
+import { useIsFrozenRoute } from '@/shared/navigation/transition/route-phase-context'
 
 import { AlertDialogContext } from '../lib/global-alert-dialog'
 
 export const useAlertDialog = () => {
   const context = use(AlertDialogContext)
   if (!context) throw new Error('useAlertDialog must be used within an AlertDialogProvider')
-  return context
+  const isFrozen = useIsFrozenRoute()
+
+  const safeOpen = useCallback(
+    (options: Parameters<typeof context.open>[0]) => {
+      if (isFrozen) return
+      context.open(options)
+    },
+    [context, isFrozen]
+  )
+
+  return useMemo(
+    () => ({
+      ...context,
+      open: safeOpen,
+    }),
+    [context, safeOpen]
+  )
 }

--- a/apps/react/src/shared/layout/screen/content.tsx
+++ b/apps/react/src/shared/layout/screen/content.tsx
@@ -1,0 +1,43 @@
+import { useMemo, type HTMLAttributes, type ReactNode } from 'react'
+
+import { useScreenLayoutContext } from './context'
+
+interface ScreenContentProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode
+}
+
+export function ScreenContent({ children, className, style, ...rest }: ScreenContentProps) {
+  const layout = useScreenLayoutContext()
+
+  const resolvedStyle = useMemo(() => {
+    const headerHeight = layout?.headerHeight ?? 0
+
+    if (style?.paddingTop !== undefined) {
+      return style
+    }
+
+    let paddingTop: string | undefined
+
+    if (layout?.headerBehavior === 'overlay') {
+      paddingTop = headerHeight > 0 ? `${headerHeight}px` : 'var(--safe-top)'
+    }
+
+    if (!paddingTop && !style) return undefined
+
+    return {
+      ...(style ?? {}),
+      ...(paddingTop ? { paddingTop } : {}),
+    }
+  }, [layout?.headerBehavior, layout?.headerHeight, style])
+
+  return (
+    <div
+      data-role="screen-content"
+      className={['min-h-0 flex-1 overflow-y-auto', className].filter(Boolean).join(' ')}
+      style={resolvedStyle}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/react/src/shared/layout/screen/context.ts
+++ b/apps/react/src/shared/layout/screen/context.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react'
+
+export type HeaderBehavior = 'static' | 'overlay'
+
+export interface ScreenLayoutContextValue {
+  headerHeight: number
+  headerBehavior: HeaderBehavior
+  setHeader: (config: { behavior: HeaderBehavior; height: number }) => void
+  unregisterHeader: () => void
+}
+
+export const ScreenLayoutContext = createContext<ScreenLayoutContextValue | null>(null)
+
+export function useScreenLayoutContext() {
+  return useContext(ScreenLayoutContext)
+}

--- a/apps/react/src/shared/layout/screen/header.tsx
+++ b/apps/react/src/shared/layout/screen/header.tsx
@@ -1,0 +1,61 @@
+import { useLayoutEffect, useRef, type ReactNode } from 'react'
+
+import { useScreenLayoutContext, type HeaderBehavior } from './context'
+
+interface ScreenHeaderProps {
+  children?: ReactNode
+  behavior?: HeaderBehavior
+  className?: string
+}
+
+export function ScreenHeader({ children, behavior = 'static', className }: ScreenHeaderProps) {
+  const layout = useScreenLayoutContext()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    const node = containerRef.current
+
+    if (!layout) return
+
+    if (!node) {
+      layout.unregisterHeader()
+      return
+    }
+
+    const readHeight = () => {
+      const next = Math.max(0, node.offsetHeight)
+      layout.setHeader({ behavior, height: next })
+    }
+
+    readHeight()
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(readHeight)
+      observer.observe(node)
+      return () => {
+        observer.disconnect()
+        layout.unregisterHeader()
+      }
+    }
+
+    return () => {
+      layout.unregisterHeader()
+    }
+  }, [behavior, layout, children])
+
+  if (!children) return null
+
+  if (behavior === 'overlay') {
+    return (
+      <div ref={containerRef} className={['absolute top-0 z-40 w-full', className].filter(Boolean).join(' ')}>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className={className}>
+      {children}
+    </div>
+  )
+}

--- a/apps/react/src/shared/layout/screen/index.ts
+++ b/apps/react/src/shared/layout/screen/index.ts
@@ -1,0 +1,8 @@
+import { ScreenContent } from './content'
+import { useScreenLayoutContext } from './context'
+import { ScreenHeader } from './header'
+import { ScreenRoot } from './root'
+
+export const Screen = Object.assign(ScreenRoot, { Header: ScreenHeader, Content: ScreenContent })
+
+export const useScreenLayout = useScreenLayoutContext

--- a/apps/react/src/shared/layout/screen/root.tsx
+++ b/apps/react/src/shared/layout/screen/root.tsx
@@ -1,0 +1,43 @@
+import { useMemo, useState, useCallback } from 'react'
+
+import { ScreenLayoutContext, type HeaderBehavior } from './context'
+
+import type { ReactNode } from 'react'
+
+interface ScreenRootProps {
+  children: ReactNode
+  className?: string
+}
+
+export function ScreenRoot({ children, className }: ScreenRootProps) {
+  const [headerHeight, setHeaderHeight] = useState(0)
+  const [headerBehavior, setHeaderBehavior] = useState<HeaderBehavior>('static')
+
+  const setHeader = useCallback((config: { behavior: HeaderBehavior; height: number }) => {
+    setHeaderBehavior(config.behavior)
+    setHeaderHeight(config.height)
+  }, [])
+
+  const unregisterHeader = useCallback(() => {
+    setHeaderBehavior('static')
+    setHeaderHeight(0)
+  }, [])
+
+  const contextValue = useMemo(
+    () => ({
+      headerHeight,
+      headerBehavior,
+      setHeader,
+      unregisterHeader,
+    }),
+    [headerHeight, headerBehavior, setHeader, unregisterHeader]
+  )
+
+  return (
+    <ScreenLayoutContext.Provider value={contextValue}>
+      <div className={['relative flex h-full w-full flex-col overflow-hidden', className].filter(Boolean).join(' ')}>
+        {children}
+      </div>
+    </ScreenLayoutContext.Provider>
+  )
+}

--- a/apps/react/src/shared/navigation/back.ts
+++ b/apps/react/src/shared/navigation/back.ts
@@ -1,0 +1,39 @@
+let manualBackIntent = false
+let manualBackResetTimer: ReturnType<typeof setTimeout> | null = null
+
+const RESET_TIMEOUT_MS = 1000
+
+const clearManualBackIntent = () => {
+  manualBackIntent = false
+  if (manualBackResetTimer) {
+    clearTimeout(manualBackResetTimer)
+    manualBackResetTimer = null
+  }
+}
+
+export function markManualBack() {
+  manualBackIntent = true
+  if (manualBackResetTimer) {
+    clearTimeout(manualBackResetTimer)
+  }
+  manualBackResetTimer = setTimeout(() => {
+    clearManualBackIntent()
+  }, RESET_TIMEOUT_MS)
+}
+
+export function consumeManualBack() {
+  const current = manualBackIntent
+  clearManualBackIntent()
+  return current
+}
+
+type RouterLike = {
+  history: {
+    back: () => void
+  }
+}
+
+export function backWithHistory(router: RouterLike) {
+  markManualBack()
+  router.history.back()
+}

--- a/apps/react/src/shared/navigation/navigation-entry.ts
+++ b/apps/react/src/shared/navigation/navigation-entry.ts
@@ -1,0 +1,21 @@
+import type { ParsedLocation } from '@tanstack/router-core'
+
+type NavigationState = Record<string, unknown> & {
+  key?: string
+}
+
+export interface NavigationEntry {
+  key: string
+  location: ParsedLocation
+}
+
+export const getLocationKey = (location: ParsedLocation): string => {
+  const state = location.state as NavigationState | undefined
+  const key = typeof state?.key === 'string' ? state.key : undefined
+  return key ?? location.href
+}
+
+export const createNavigationEntry = (location: ParsedLocation): NavigationEntry => ({
+  key: getLocationKey(location),
+  location,
+})

--- a/apps/react/src/shared/navigation/transition/blocker.ts
+++ b/apps/react/src/shared/navigation/transition/blocker.ts
@@ -1,0 +1,85 @@
+import { buildTransitionMetadata } from './utils'
+
+import type { HistoryAction, HistoryLikeLocation, ParsedHistoryStateLike } from './types'
+import type { TransitionControllerDeps } from './types'
+
+export const createHistoryBlocker =
+  (deps: TransitionControllerDeps) =>
+  ({
+    action,
+    nextLocation,
+    currentLocation,
+  }: {
+    action: HistoryAction | string | undefined
+    nextLocation: HistoryLikeLocation
+    currentLocation: HistoryLikeLocation
+  }) => {
+    const nextParsed = deps.parseLocation(nextLocation)
+    const currentParsed = deps.parseLocation(currentLocation)
+    const nextState = (nextLocation.state ?? {}) as ParsedHistoryStateLike
+
+    const metadata = buildTransitionMetadata(action, nextParsed, currentParsed, nextState)
+
+    const transitionId = deps.generateTransitionId()
+
+    if (metadata.nextState?.skipTransition === true) {
+      const href = (nextParsed as any)?.href ?? (nextParsed as any)?.pathname
+      // 커밋 직후에 플래그 해제
+      setTimeout(() => {
+        try {
+          deps.replaceState?.({ to: href, state: { ...metadata.nextState, skipTransition: false } })
+        } catch (e) {
+          void e
+        }
+      }, 0)
+      if (metadata.direction === 'forward') {
+        deps.setSnapshot(null)
+        return false
+      }
+    }
+    const manualBackIntent = metadata.direction === 'back' ? deps.consumeManualBackIntent() : false
+
+    const initiator =
+      metadata.direction === 'back'
+        ? metadata.action === 'BACK'
+          ? manualBackIntent
+            ? 'manual'
+            : 'system'
+          : 'manual'
+        : 'manual'
+
+    let resolved = false
+
+    return new Promise<boolean>((resolveBlock) => {
+      const clearIfCurrent = () => deps.clearSnapshotById(transitionId)
+
+      const proceed = () => {
+        if (!resolved) {
+          resolved = true
+          resolveBlock(false)
+          clearIfCurrent()
+        }
+      }
+
+      const reset = () => {
+        if (!resolved) {
+          resolved = true
+          resolveBlock(true)
+          clearIfCurrent()
+        }
+      }
+
+      deps.setSnapshot({
+        id: transitionId,
+        phase: 'pending',
+        action: metadata.action ?? 'PUSH',
+        direction: metadata.direction,
+        fromEntry: metadata.fromEntry,
+        toEntry: metadata.toEntry,
+        skip: false,
+        initiator,
+        proceed,
+        reset,
+      })
+    })
+  }

--- a/apps/react/src/shared/navigation/transition/context.tsx
+++ b/apps/react/src/shared/navigation/transition/context.tsx
@@ -1,0 +1,90 @@
+import { useRouter, useRouterState } from '@tanstack/react-router'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+
+import { consumeManualBack } from '../back'
+import { getLocationKey } from '../navigation-entry'
+import { createHistoryBlocker } from './blocker'
+import { parseHistoryLocation } from './utils'
+
+import type { NavigationTransitionContextValue, NavigationTransitionSnapshot } from './types'
+import type { HistoryLikeLocation } from './types'
+
+const NavigationTransitionContext = createContext<NavigationTransitionContextValue | null>(null)
+
+const INITIAL_SNAPSHOT: NavigationTransitionSnapshot | null = null
+
+export function NavigationTransitionProvider({ children }: { children: ReactNode }) {
+  const router = useRouter()
+  const routerState = useRouterState()
+  const latestLocation = routerState?.location ?? router.state.location
+
+  const [snapshot, setSnapshot] = useState<NavigationTransitionSnapshot | null>(INITIAL_SNAPSHOT)
+  const transitionIdRef = useRef(0)
+
+  const clear = useCallback(() => {
+    setSnapshot(INITIAL_SNAPSHOT)
+  }, [])
+
+  const parseLocation = useCallback(
+    (historyLocation: HistoryLikeLocation) =>
+      parseHistoryLocation(router.parseLocation, historyLocation, latestLocation),
+    [latestLocation, router.parseLocation]
+  )
+
+  const clearSnapshotById = useCallback((id: number) => {
+    setSnapshot((prev) => (prev && prev.id === id ? null : prev))
+  }, [])
+
+  useEffect(() => {
+    const unblock = router.history.block({
+      blockerFn: createHistoryBlocker({
+        parseLocation,
+        consumeManualBackIntent: consumeManualBack,
+        setSnapshot,
+        clearSnapshotById,
+        generateTransitionId: () => {
+          transitionIdRef.current += 1
+          return transitionIdRef.current
+        },
+        replaceState: ({ to, state }) => {
+          try {
+            router.history.replace({ to, state } as any)
+          } catch (e) {
+            void e
+          }
+        },
+      }),
+    })
+
+    return () => {
+      unblock?.()
+    }
+  }, [parseLocation, router.history, clearSnapshotById])
+
+  useEffect(() => {
+    if (snapshot) {
+      const currentKey = getLocationKey(latestLocation)
+      if (snapshot.toEntry.key === currentKey) {
+        setSnapshot((prev) => (prev && prev.id === snapshot.id ? null : prev))
+      }
+    }
+  }, [latestLocation, snapshot])
+
+  const contextValue = useMemo<NavigationTransitionContextValue>(
+    () => ({
+      snapshot,
+      clear,
+    }),
+    [clear, snapshot]
+  )
+
+  return <NavigationTransitionContext.Provider value={contextValue}>{children}</NavigationTransitionContext.Provider>
+}
+
+export function useNavigationTransition() {
+  const context = useContext(NavigationTransitionContext)
+  if (!context) {
+    throw new Error('useNavigationTransition must be used within NavigationTransitionProvider')
+  }
+  return context
+}

--- a/apps/react/src/shared/navigation/transition/index.ts
+++ b/apps/react/src/shared/navigation/transition/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './context'

--- a/apps/react/src/shared/navigation/transition/route-phase-context.ts
+++ b/apps/react/src/shared/navigation/transition/route-phase-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+type RoutePhase = 'live' | 'frozen'
+
+const RoutePhaseContext = createContext<RoutePhase>('live')
+
+export const RoutePhaseProvider = RoutePhaseContext.Provider
+
+export function useRoutePhase() {
+  return useContext(RoutePhaseContext)
+}
+
+export function useIsFrozenRoute() {
+  return useRoutePhase() === 'frozen'
+}

--- a/apps/react/src/shared/navigation/transition/types.ts
+++ b/apps/react/src/shared/navigation/transition/types.ts
@@ -1,0 +1,56 @@
+import type { NavigationEntry } from '../navigation-entry'
+import type { ParsedLocation } from '@tanstack/router-core'
+
+export type HistoryAction = 'PUSH' | 'REPLACE' | 'FORWARD' | 'BACK' | 'GO'
+export type Direction = 'forward' | 'back'
+
+export type TransitionPhase = 'idle' | 'pending'
+export type NavigationInitiator = 'manual' | 'system'
+
+export interface NavigationTransitionSnapshot {
+  id: number
+  phase: TransitionPhase
+  action: HistoryAction
+  direction: Direction
+  fromEntry: NavigationEntry | null
+  toEntry: NavigationEntry
+  skip: boolean
+  initiator: NavigationInitiator
+  proceed: () => void
+  reset: () => void
+}
+
+export interface NavigationTransitionContextValue {
+  snapshot: NavigationTransitionSnapshot | null
+  clear: () => void
+}
+
+export interface HistoryLikeLocation {
+  href: string
+  pathname: string
+  search: string
+  hash: string
+  state: Record<string, unknown>
+}
+
+export type ParsedHistoryStateLike = {
+  __TSR_index?: number
+  skipTransition?: boolean
+}
+
+export interface TransitionMetadata {
+  action: HistoryAction | undefined
+  direction: Direction
+  toEntry: NavigationEntry
+  fromEntry: NavigationEntry
+  nextState: ParsedHistoryStateLike
+}
+
+export interface TransitionControllerDeps {
+  parseLocation: (historyLocation: HistoryLikeLocation) => ParsedLocation
+  consumeManualBackIntent: () => boolean
+  setSnapshot: (snapshot: NavigationTransitionSnapshot | null) => void
+  clearSnapshotById: (id: number) => void
+  generateTransitionId: () => number
+  replaceState?: (opts: { to: string; state?: Record<string, unknown> }) => void
+}

--- a/apps/react/src/shared/navigation/transition/utils.ts
+++ b/apps/react/src/shared/navigation/transition/utils.ts
@@ -1,0 +1,84 @@
+import { createNavigationEntry } from '../navigation-entry'
+
+import type { Direction, HistoryAction, HistoryLikeLocation, ParsedHistoryStateLike, TransitionMetadata } from './types'
+import type { ParsedLocation } from '@tanstack/router-core'
+
+/**
+ * History 액션을 표준 문자열로 변환
+ */
+export const normalizeAction = (action: HistoryAction | string | undefined): HistoryAction | undefined => {
+  if (!action) return undefined
+  const upper = action.toString().toUpperCase()
+  if (upper === 'PUSH' || upper === 'REPLACE' || upper === 'BACK' || upper === 'FORWARD' || upper === 'GO') {
+    return upper as HistoryAction
+  }
+  return undefined
+}
+
+/**
+ * TSR가 부여한 히스토리 인덱스 추출
+ */
+const getHistoryIndex = (location: ParsedLocation, explicitState?: ParsedHistoryStateLike): number | null => {
+  const state = explicitState ?? (location.state as ParsedHistoryStateLike | undefined)
+  const index = state?.__TSR_index
+  return typeof index === 'number' ? index : null
+}
+
+/**
+ * 이동 방향(back/forward)을 결정
+ */
+const resolveDirection = (
+  action: HistoryAction | undefined,
+  nextParsed: ParsedLocation,
+  currentParsed: ParsedLocation,
+  nextState: ParsedHistoryStateLike
+): Direction => {
+  if (action === 'BACK') return 'back'
+  if (action === 'FORWARD') return 'forward'
+
+  const nextIndex = getHistoryIndex(nextParsed, nextState)
+  const currentIndex = getHistoryIndex(currentParsed)
+
+  if (nextIndex !== null && currentIndex !== null) {
+    if (nextIndex < currentIndex) return 'back'
+    if (nextIndex > currentIndex) return 'forward'
+  }
+
+  return action === 'REPLACE' ? 'forward' : 'forward'
+}
+
+/**
+ * 히스토리 Location 파싱
+ */
+export const parseHistoryLocation = (
+  routerParseLocation: (previousLocation?: ParsedLocation, locationToParse?: HistoryLikeLocation) => ParsedLocation,
+  historyLocation: HistoryLikeLocation,
+  fallback: ParsedLocation
+): ParsedLocation => {
+  try {
+    return routerParseLocation(fallback, historyLocation)
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * 전환 메타데이터 구성(액션/방향/엔트리)
+ */
+export const buildTransitionMetadata = (
+  action: HistoryAction | string | undefined,
+  nextParsed: ParsedLocation,
+  currentParsed: ParsedLocation,
+  nextState: ParsedHistoryStateLike
+): TransitionMetadata => {
+  const normalizedAction = normalizeAction(action)
+  const direction = resolveDirection(normalizedAction, nextParsed, currentParsed, nextState)
+
+  return {
+    action: normalizedAction,
+    direction,
+    toEntry: createNavigationEntry(nextParsed),
+    fromEntry: createNavigationEntry(currentParsed),
+    nextState,
+  }
+}

--- a/apps/react/src/shared/navigation/use-frozen-router-context.ts
+++ b/apps/react/src/shared/navigation/use-frozen-router-context.ts
@@ -1,0 +1,45 @@
+import cloneDeep from 'lodash-es/cloneDeep'
+
+// 라우터에서 실제로 사용하는 필드 좁힌 타입
+type RouterOptionsLike = { context?: unknown; routesById?: unknown }
+type RouterLike = {
+  options?: RouterOptionsLike
+  routesById?: unknown
+  routeTree?: unknown
+}
+
+/**
+ * options.context 값을 스냅샷에도 보존해 훅/컨텍스트 유지
+ */
+const preserveOptionsContext = (snapshot: RouterLike, original: RouterLike) => {
+  if (snapshot?.options && original?.options) {
+    snapshot.options = {
+      ...snapshot.options,
+      context: original.options.context,
+    }
+  }
+}
+
+/**
+ *  효과 실행 시점에 고정된 라우터 컨텍스트를 캡처하여 전환 애니메이션 동안 동일한 라우트 트리/레지스트리를 참조
+ */
+export function snapshotRouterContext<T extends RouterLike>(liveRouter: T): T {
+  const snapshot = cloneDeep(liveRouter) as T
+  preserveOptionsContext(snapshot, liveRouter)
+
+  // routesById/routeTree 참조 보존
+  if (liveRouter?.routesById) {
+    ;(snapshot as RouterLike).routesById = liveRouter.routesById
+  }
+  if (liveRouter?.options?.routesById) {
+    ;(snapshot as RouterLike).options = {
+      ...((snapshot as RouterLike).options || {}),
+      routesById: liveRouter.options?.routesById,
+    }
+  }
+  if (liveRouter?.routeTree) {
+    ;(snapshot as RouterLike).routeTree = liveRouter.routeTree
+  }
+
+  return snapshot
+}

--- a/apps/react/src/shared/navigation/use-frozen-router-context.ts
+++ b/apps/react/src/shared/navigation/use-frozen-router-context.ts
@@ -1,11 +1,18 @@
 import cloneDeep from 'lodash-es/cloneDeep'
 
+import type { BuildNextOptions, ParsedLocation } from '@tanstack/router-core'
+
 // 라우터에서 실제로 사용하는 필드 좁힌 타입
 type RouterOptionsLike = { context?: unknown; routesById?: unknown }
-type RouterLike = {
+export type RouterLike = {
   options?: RouterOptionsLike
   routesById?: unknown
   routeTree?: unknown
+  buildLocation: (opts?: BuildNextOptions, matchedRoutesResult?: unknown) => ParsedLocation
+}
+
+type SnapshotOptions = {
+  location?: ParsedLocation
 }
 
 /**
@@ -23,7 +30,7 @@ const preserveOptionsContext = (snapshot: RouterLike, original: RouterLike) => {
 /**
  *  효과 실행 시점에 고정된 라우터 컨텍스트를 캡처하여 전환 애니메이션 동안 동일한 라우트 트리/레지스트리를 참조
  */
-export function snapshotRouterContext<T extends RouterLike>(liveRouter: T): T {
+export function snapshotRouterContext<T extends RouterLike>(liveRouter: T, options?: SnapshotOptions): T {
   const snapshot = cloneDeep(liveRouter) as T
   preserveOptionsContext(snapshot, liveRouter)
 
@@ -39,6 +46,16 @@ export function snapshotRouterContext<T extends RouterLike>(liveRouter: T): T {
   }
   if (liveRouter?.routeTree) {
     ;(snapshot as RouterLike).routeTree = liveRouter.routeTree
+  }
+
+  const fromLocation = options?.location ?? liveRouter.buildLocation()
+
+  if (fromLocation) {
+    const originalBuildLocation = snapshot.buildLocation.bind(snapshot)
+    snapshot.buildLocation = (opts?: BuildNextOptions, matchedRoutesResult?: unknown) => {
+      const nextOpts = typeof opts === 'object' ? { ...opts, _fromLocation: fromLocation } : opts
+      return originalBuildLocation(nextOpts, matchedRoutesResult)
+    }
   }
 
   return snapshot

--- a/apps/react/src/shared/navigation/use-go-back.ts
+++ b/apps/react/src/shared/navigation/use-go-back.ts
@@ -1,0 +1,12 @@
+import { useRouter } from '@tanstack/react-router'
+import { useCallback } from 'react'
+
+import { backWithHistory } from './back'
+
+export function useGoBack() {
+  const router = useRouter()
+
+  return useCallback(() => {
+    backWithHistory(router)
+  }, [router])
+}

--- a/apps/react/src/shared/ui/bottom-navigation.tsx
+++ b/apps/react/src/shared/ui/bottom-navigation.tsx
@@ -66,7 +66,13 @@ export function BottomNavigation() {
           const Icon = active ? item.activeIcon : item.icon
 
           return (
-            <Link key={item.id} to={item.path} className="flex flex-1 flex-col items-center justify-center gap-1">
+            <Link
+              key={item.id}
+              to={item.path}
+              replace
+              state={{ skipTransition: true }}
+              className="flex flex-1 flex-col items-center justify-center gap-1"
+            >
               <Icon className="h-6 w-6" />
               <span className={cn('text-[11px] font-medium', active ? 'text-gray-iron-950' : 'text-gray-iron-400')}>
                 {item.label}

--- a/apps/react/src/shared/ui/header-bar.tsx
+++ b/apps/react/src/shared/ui/header-bar.tsx
@@ -1,7 +1,7 @@
-import { useRouter } from '@tanstack/react-router'
 import { LucideChevronLeft } from 'lucide-react'
 
 import { cn } from '@/shared/lib/cn'
+import { useGoBack } from '@/shared/navigation/use-go-back'
 
 import type { ReactNode } from 'react'
 
@@ -22,13 +22,13 @@ export function DetailHeaderBar({
   className,
   showBackButton = true,
 }: DetailHeaderBarProps) {
-  const router = useRouter()
+  const goBack = useGoBack()
 
   const handleBackClick = () => {
     if (onBackClick) {
       onBackClick()
     } else {
-      router.history.back()
+      goBack()
     }
   }
 

--- a/apps/react/src/shared/ui/router-error.tsx
+++ b/apps/react/src/shared/ui/router-error.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import momoErrorImage from '@/assets/images/momo-error.png'
 import { ErrorReporter } from '@/shared/analytics'
+import { Screen } from '@/shared/layout/screen'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
 interface RouterErrorProps {
@@ -32,25 +33,19 @@ export function RouterError({ error }: RouterErrorProps) {
   }
 
   return (
-    <div className="flex h-screen flex-col bg-white">
-      {/* 헤더 네비게이션바 */}
-      <DetailHeaderBar showBackButton={true} />
+    <Screen>
+      <Screen.Header className="pt-safe-top bg-white">
+        <DetailHeaderBar showBackButton={true} />
+      </Screen.Header>
 
-      {/* 컨텐츠 */}
-      <div className="mt-[106px] flex flex-1 flex-col items-center px-5">
-        {/* 에러 이미지 */}
-        <img src={momoErrorImage} alt="에러 이미지" className="h-[236px] w-[320px] object-contain" />
+      <Screen.Content className="flex flex-col items-center justify-between px-5">
+        <div className="mt-[106px] flex flex-col items-center">
+          <img src={momoErrorImage} alt="에러 이미지" className="h-[236px] w-[320px] object-contain" />
+          <h1 className="heading1-bold mt-6 text-gray-iron-950">일시적인 오류가 발생했어요</h1>
+          <p className="body2-medium mt-1 text-gray-iron-500">잠시 후에 다시 시도해 주세요!</p>
+        </div>
 
-        {/* 제목 */}
-        <h1 className="heading1-bold mt-6 text-gray-iron-950">일시적인 오류가 발생했어요</h1>
-
-        {/* 설명 */}
-        <p className="body2-medium mt-1 text-gray-iron-500">잠시 후에 다시 시도해 주세요!</p>
-
-        <div className="flex-1" />
-
-        {/* 버튼 */}
-        <div className="mb-5 w-full">
+        <div className="w-full pb-5">
           <button
             onClick={handleGoHome}
             className="body1-semibold h-[54px] w-full rounded-lg bg-gray-iron-700 text-white"
@@ -58,7 +53,7 @@ export function RouterError({ error }: RouterErrorProps) {
             홈으로 돌아가기
           </button>
         </div>
-      </div>
-    </div>
+      </Screen.Content>
+    </Screen>
   )
 }

--- a/apps/react/src/shared/ui/stacked-outlet.tsx
+++ b/apps/react/src/shared/ui/stacked-outlet.tsx
@@ -69,7 +69,9 @@ export function StackedOutlet({
     setCurrentDirection(snapshot.direction)
 
     if (snapshot.direction === 'back' || snapshot.direction === 'forward') {
-      const frozenContext = snapshotRouterContext(liveRouter)
+      const frozenContext = snapshotRouterContext(liveRouter as RouterLike, {
+        location: snapshot.fromEntry?.location,
+      })
       const entry: FrozenEntry = {
         id: `${snapshot.id}-${snapshot.fromEntry?.key ?? snapshot.fromEntry?.location.pathname ?? 'unknown'}`,
         pathname: snapshot.fromEntry?.location.pathname ?? '',

--- a/apps/react/src/shared/ui/stacked-outlet.tsx
+++ b/apps/react/src/shared/ui/stacked-outlet.tsx
@@ -1,0 +1,209 @@
+import { Outlet, getRouterContext, useRouterState } from '@tanstack/react-router'
+import { motion, useReducedMotion } from 'motion/react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
+
+import { useNavigationTransition } from '@/shared/navigation/transition'
+import { RoutePhaseProvider } from '@/shared/navigation/transition/route-phase-context'
+import { snapshotRouterContext } from '@/shared/navigation/use-frozen-router-context'
+
+type Direction = 'forward' | 'back' | 'none'
+
+type FrozenEntry = {
+  id: string
+  pathname: string
+  context: any
+  direction: Direction
+}
+
+const DEFAULT_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1]
+const EXIT_TRANSLATE = 100
+const toPercent = (value: number) => `${value}%`
+export function StackedOutlet({
+  duration = 0.28,
+  ease = DEFAULT_EASE,
+  keep = 1,
+}: {
+  duration?: number
+  ease?: [number, number, number, number]
+  keep?: number
+}) {
+  const RouterContext = getRouterContext()
+  const liveRouter = useContext(RouterContext)
+  const prefersReducedMotion = useReducedMotion() ?? false
+  const { snapshot, clear } = useNavigationTransition()
+
+  const routerState = useRouterState()
+  const location = routerState?.location ?? (liveRouter as any)?.state?.location
+  const href = location?.href ?? location?.pathname ?? ''
+
+  const [frozenStack, setFrozenStack] = useState<FrozenEntry[]>([])
+  const [currentDirection, setCurrentDirection] = useState<Direction>('none')
+  const lastHandledSnapshotRef = useRef<number | null>(null)
+
+  const animationDuration = prefersReducedMotion ? 0 : duration
+
+  useEffect(() => {
+    if (!snapshot) return
+    if (snapshot.id === lastHandledSnapshotRef.current) {
+      return
+    }
+    lastHandledSnapshotRef.current = snapshot.id
+
+    if (snapshot.skip) {
+      snapshot.proceed()
+      clear()
+      setCurrentDirection('none')
+      return
+    }
+
+    const shouldSkipBackAnimation = snapshot.direction === 'back' && snapshot.initiator === 'system'
+
+    if (shouldSkipBackAnimation) {
+      setCurrentDirection('none')
+      snapshot.proceed()
+      clear()
+      setFrozenStack([])
+      return
+    }
+
+    setCurrentDirection(snapshot.direction)
+
+    if (snapshot.direction === 'back' || snapshot.direction === 'forward') {
+      const frozenContext = snapshotRouterContext(liveRouter)
+      const entry: FrozenEntry = {
+        id: `${snapshot.id}-${snapshot.fromEntry?.key ?? snapshot.fromEntry?.location.pathname ?? 'unknown'}`,
+        pathname: snapshot.fromEntry?.location.pathname ?? '',
+        context: frozenContext,
+        direction: snapshot.direction,
+      }
+
+      setFrozenStack((prev) => {
+        const next = [...prev, entry]
+        while (next.length > keep) {
+          next.shift()
+        }
+        return next
+      })
+    } else {
+      setFrozenStack([])
+    }
+
+    snapshot.proceed()
+    clear()
+  }, [snapshot, liveRouter, keep, clear])
+
+  const handleFrozenExit = (id: string) => {
+    setFrozenStack((prev) => prev.filter((entry) => entry.id !== id))
+  }
+
+  const handleLiveComplete = () => {
+    setCurrentDirection('none')
+  }
+
+  const liveInitialStyle = useMemo(() => {
+    if (prefersReducedMotion || currentDirection === 'none') {
+      return { x: 0 }
+    }
+    if (currentDirection === 'back') {
+      return { x: 0 }
+    }
+    if (currentDirection === 'forward') {
+      return { x: toPercent(EXIT_TRANSLATE) }
+    }
+    return { x: 0 }
+  }, [prefersReducedMotion, currentDirection])
+
+  const liveAnimationTarget = { x: 0 }
+  const liveTransition = { duration: animationDuration, ease }
+
+  const liveZ = currentDirection === 'back' ? 'z-0' : 'z-10'
+
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      {frozenStack.map((entry) => (
+        <RoutePhaseProvider key={entry.id} value="frozen">
+          <FrozenScreen
+            entry={entry}
+            prefersReducedMotion={prefersReducedMotion}
+            duration={animationDuration}
+            ease={ease}
+            onExitComplete={handleFrozenExit}
+          />
+        </RoutePhaseProvider>
+      ))}
+
+      <RoutePhaseProvider value="live">
+        <motion.div
+          key={href}
+          className={`relative ${liveZ} h-full w-full`}
+          initial={liveInitialStyle}
+          animate={liveAnimationTarget}
+          transition={liveTransition}
+          onAnimationComplete={handleLiveComplete}
+        >
+          <RouterContext.Provider value={liveRouter}>
+            <Outlet />
+          </RouterContext.Provider>
+        </motion.div>
+      </RoutePhaseProvider>
+    </div>
+  )
+}
+
+function FrozenScreen({
+  entry,
+  prefersReducedMotion,
+  duration,
+  ease,
+  onExitComplete,
+}: {
+  entry: FrozenEntry
+  prefersReducedMotion: boolean
+  duration: number
+  ease: [number, number, number, number]
+  onExitComplete: (id: string) => void
+}) {
+  const RouterContext = getRouterContext()
+  const transition = prefersReducedMotion ? { duration: 0 } : { duration, ease }
+  const target = entry.direction === 'back' ? { x: toPercent(EXIT_TRANSLATE) } : { x: 0 }
+
+  useEffect(() => {
+    if (entry.direction !== 'forward') return
+
+    if (prefersReducedMotion || duration === 0) {
+      onExitComplete(entry.id)
+      return
+    }
+
+    if (typeof window === 'undefined') {
+      onExitComplete(entry.id)
+      return
+    }
+
+    const timeout = window.setTimeout(() => onExitComplete(entry.id), duration * 1000)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [entry.direction, prefersReducedMotion, duration, entry.id, onExitComplete])
+
+  const handleAnimationComplete = () => {
+    if (entry.direction === 'back') {
+      onExitComplete(entry.id)
+    }
+  }
+
+  return (
+    <motion.div
+      className={`pointer-events-none absolute inset-0 ${entry.direction === 'back' ? 'z-20' : 'z-0'} h-full w-full`}
+      initial={{ x: 0 }}
+      animate={prefersReducedMotion ? { x: 0 } : target}
+      transition={transition}
+      onAnimationComplete={handleAnimationComplete}
+    >
+      <RouterContext.Provider value={entry.context}>
+        <Outlet />
+      </RouterContext.Provider>
+    </motion.div>
+  )
+}

--- a/apps/react/src/shared/ui/transition-viewport.tsx
+++ b/apps/react/src/shared/ui/transition-viewport.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export function TransitionViewport({ children }: { children: ReactNode }) {
+  return <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">{children}</div>
+}

--- a/apps/react/src/types/history.d.ts
+++ b/apps/react/src/types/history.d.ts
@@ -1,0 +1,5 @@
+declare module '@tanstack/history' {
+  interface HistoryState {
+    skipTransition?: boolean
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ catalogs:
       version: 2.1.1
     lucide-react:
       specifier: latest
-      version: 0.544.0
+      version: 0.546.0
     react:
       specifier: 19.0.0
       version: 19.0.0
@@ -245,12 +245,15 @@ importers:
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       lottie-react:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       lucide-react:
         specifier: catalog:react
-        version: 0.544.0(react@19.0.0)
+        version: 0.546.0(react@19.0.0)
       path-to-regexp:
         specifier: 'catalog:'
         version: 8.2.0
@@ -5681,6 +5684,10 @@ packages:
       { integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA== }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
+  lodash-es@4.17.21:
+    resolution:
+      { integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw== }
+
   lodash.camelcase@4.3.0:
     resolution:
       { integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA== }
@@ -5767,9 +5774,9 @@ packages:
     resolution:
       { integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w== }
 
-  lucide-react@0.544.0:
+  lucide-react@0.546.0:
     resolution:
-      { integrity: sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw== }
+      { integrity: sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ== }
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -13143,6 +13150,8 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
+  lodash-es@4.17.21: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.debounce@4.0.8: {}
@@ -13202,7 +13211,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.544.0(react@19.0.0):
+  lucide-react@0.546.0(react@19.0.0):
     dependencies:
       react: 19.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       lucide-react:
         specifier: catalog:react
         version: 0.546.0(react@19.0.0)
+      motion:
+        specifier: ^12.23.24
+        version: 12.23.24(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       path-to-regexp:
         specifier: 'catalog:'
         version: 8.2.0
@@ -4772,6 +4775,21 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@12.23.24:
+    resolution:
+      { integrity: sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w== }
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   freeport-async@2.0.0:
     resolution:
       { integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ== }
@@ -5992,9 +6010,28 @@ packages:
     resolution:
       { integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw== }
 
+  motion-dom@12.23.23:
+    resolution:
+      { integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA== }
+
   motion-utils@12.23.6:
     resolution:
       { integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ== }
+
+  motion@12.23.24:
+    resolution:
+      { integrity: sha512-Rc5E7oe2YZ72N//S3QXGzbnXgqNrTESv8KKxABR20q2FLch9gHLo0JLyYo2hZ238bZ9Gx6cWhj9VO0IgwbMjCw== }
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mrmime@2.0.1:
     resolution:
@@ -12434,6 +12471,15 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
+  framer-motion@12.23.24(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      motion-dom: 12.23.23
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
@@ -13470,7 +13516,19 @@ snapshots:
     dependencies:
       motion-utils: 12.23.6
 
+  motion-dom@12.23.23:
+    dependencies:
+      motion-utils: 12.23.6
+
   motion-utils@12.23.6: {}
+
+  motion@12.23.24(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      framer-motion: 12.23.24(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   mrmime@2.0.1:
     optional: true


### PR DESCRIPTION
## 이슈 번호

> #MM-157

## 작업내용  
- 변경한 주요 내용 목록  
  - tanstack router 의 blocker를 통해 라우팅 중단 후 애니메이션 진행하고 proceed
  - 각 페이지 StackedOutlet으로 감싸 애니메이션 진행 시 live, frozen 분리 -> forward 진입은 슬라이드 인, back은 이전 화면 슬라이드-아웃

## 리뷰어에게 전할 말  
- 한번 꼼꼼히 봐주시면 감사하겠습니다.
- 특정 목적지로 가는 애니메이션 스킵하고 싶으면 skipTransition: true 속성 주시면서 navigate 쓰시면 되고,
- 애니메이션 보여주면서 뒤로가기 할 때는 goBack 쓰시면 됩니다. (제스처 네비게이션이랑 구분하는 플래그 설정용)

## 스크린샷 (선택사항)

<!-- 필요한 경우 스크린샷을 첨부해주세요 -->
