### PR TITLE
[FEAT/MM-160] 소셜 로그인에 Amplitude deviceId 연동

### DIFF
--- a/apps/mobile/app/bridge/index.ts
+++ b/apps/mobile/app/bridge/index.ts
@@ -1,6 +1,6 @@
 import { Bridge, bridge, postMessageSchema } from '@webview-bridge/react-native'
 import { z } from 'zod'
-import { BridgeStore, BridgeActions, SocialLoginType, SocialLoginResult } from '@bridge/types'
+import { BridgeStore, BridgeActions, SocialLoginType, SocialLoginResult, SocialLoginOptions } from '@bridge/types'
 import { processSocialLogin, SocialLoginProvider } from '../features/auth/lib/social-login'
 import { kakaoProvider } from '../features/auth/social/kakao-provider'
 import { appleProvider } from '../features/auth/social/apple-provider'
@@ -17,7 +17,7 @@ const socialProviders: Record<SocialLoginType, SocialLoginProvider> = {
 
 export const appBridge = bridge<AppBridgeState>(({ get, set }) => {
   const actions: BridgeActions = {
-    async socialLogin(type: SocialLoginType): Promise<SocialLoginResult> {
+    async socialLogin(type: SocialLoginType, options?: SocialLoginOptions): Promise<SocialLoginResult> {
       const provider = socialProviders[type]
 
       if (!provider) {
@@ -27,7 +27,7 @@ export const appBridge = bridge<AppBridgeState>(({ get, set }) => {
         }
       }
 
-      const result = await processSocialLogin(provider)
+      const result = await processSocialLogin(provider, options)
 
       if (result.success) {
         set({ isLoggedIn: true })

--- a/apps/mobile/app/features/auth/lib/social-login.ts
+++ b/apps/mobile/app/features/auth/lib/social-login.ts
@@ -1,4 +1,4 @@
-import { SocialLoginResult } from '@bridge/types'
+import { SocialLoginResult, SocialLoginOptions } from '@bridge/types'
 import { authClient } from './auth-client'
 import { formatAxiosError, formatUnknownError, logAxiosError } from './error-utils'
 import { persistAuthSession } from './persist-auth-session'
@@ -13,12 +13,23 @@ export interface SocialLoginProvider {
   authorize(): Promise<SocialLoginRequest>
 }
 
-export async function processSocialLogin(provider: SocialLoginProvider): Promise<SocialLoginResult> {
+export async function processSocialLogin(
+  provider: SocialLoginProvider,
+  options?: SocialLoginOptions
+): Promise<SocialLoginResult> {
   try {
     const { path, payload, fetchProfile } = await provider.authorize()
 
+    const requestPayload: Record<string, unknown> = {
+      ...payload,
+    }
+
+    if (options?.deviceId && requestPayload.deviceId == null) {
+      requestPayload.deviceId = options.deviceId
+    }
+
     try {
-      const response = await authClient.post(path, payload)
+      const response = await authClient.post(path, requestPayload)
       const tokens = response.data?.data
 
       if (!tokens?.accessToken || !tokens?.refreshToken) {

--- a/apps/mobile/app/features/auth/lib/social-login.ts
+++ b/apps/mobile/app/features/auth/lib/social-login.ts
@@ -24,7 +24,7 @@ export async function processSocialLogin(
       ...payload,
     }
 
-    if (options?.deviceId && requestPayload.deviceId == null) {
+    if (options?.deviceId != null) {
       requestPayload.deviceId = options.deviceId
     }
 

--- a/apps/react/src/features/auth/lib/auth-client.ts
+++ b/apps/react/src/features/auth/lib/auth-client.ts
@@ -1,5 +1,6 @@
 import { SocialLoginType } from '@bridge/types'
 
+import { amplitude } from '@/shared/analytics'
 import bridge from '@/shared/bridge'
 import { isWebView } from '@/shared/utils/webview'
 
@@ -55,7 +56,8 @@ class AuthClient {
     if (isWebView()) {
       try {
         // 네이티브 소셜 로그인 사용
-        const result = await bridge.socialLogin(type)
+        const deviceId = amplitude.getDeviceId()
+        const result = await bridge.socialLogin(type, deviceId ? { deviceId } : undefined)
 
         if (!result.success) {
           throw new Error(result.message || '소셜 로그인에 실패했습니다.')

--- a/apps/react/src/shared/analytics/amplitude.ts
+++ b/apps/react/src/shared/analytics/amplitude.ts
@@ -10,12 +10,24 @@ let currentCategory: Category = CATEGORIES.MAIN
 class AmplitudeService {
   private isInitialized = false
   private isProduction = import.meta.env.PROD
+  private cachedDeviceId: string | undefined
 
   constructor() {
     // 프로덕션이고 Amplitude가 로드된 경우에만 초기화
     if (typeof window !== 'undefined' && window.amplitude) {
       this.isInitialized = true
+      this.cachedDeviceId = window.amplitude.getDeviceId?.() ?? this.cachedDeviceId
     }
+  }
+
+  // 디바이스 Id 조회 (웹뷰 -> 네이티브 전달)
+  getDeviceId(): string | undefined {
+    if (typeof window === 'undefined') return this.cachedDeviceId
+    const deviceId = window.amplitude?.getDeviceId?.() ?? this.cachedDeviceId
+    if (deviceId) {
+      this.cachedDeviceId = deviceId
+    }
+    return deviceId
   }
 
   // 페이지뷰 추적

--- a/apps/react/src/shared/bridge/index.ts
+++ b/apps/react/src/shared/bridge/index.ts
@@ -1,4 +1,4 @@
-import { SocialLoginType, SocialLoginResult } from '@bridge/types'
+import { SocialLoginType, SocialLoginResult, SocialLoginOptions } from '@bridge/types'
 import { BridgeStore, linkBridge } from '@webview-bridge/web'
 
 // 웹에서 사용할 브릿지 타입 정의
@@ -9,7 +9,7 @@ export interface WebBridge extends BridgeStore<WebBridge> {
   isModalOpen: boolean
 
   // 액션
-  socialLogin(type: SocialLoginType): Promise<SocialLoginResult>
+  socialLogin(type: SocialLoginType, options?: SocialLoginOptions): Promise<SocialLoginResult>
   getAuthStatus(): Promise<{ isLoggedIn: boolean }>
   getAuthToken(): Promise<{ accessToken: string | null }>
   logout({ clearAll }: { clearAll?: boolean }): Promise<{ success: boolean; message?: string }>
@@ -33,7 +33,7 @@ export const bridge = linkBridge<WebBridge>({
     isLoggedIn: false,
     keyboardHeight: 0,
     isModalOpen: false,
-    socialLogin: async () => ({ success: false }),
+    socialLogin: async (_type: SocialLoginType, _options?: SocialLoginOptions) => ({ success: false }),
     getAuthStatus: async () => ({ isLoggedIn: false }),
     getAuthToken: async () => ({ accessToken: null }),
     logout: async () => ({ success: false, message: '로그아웃 실패' }),

--- a/packages/bridge/types/index.ts
+++ b/packages/bridge/types/index.ts
@@ -15,8 +15,12 @@ export interface BridgeStore {
 }
 
 // 브릿지 액션 타입 (함수)
+export interface SocialLoginOptions {
+  deviceId?: string
+}
+
 export interface BridgeActions {
-  socialLogin(type: SocialLoginType): Promise<SocialLoginResult>
+  socialLogin(type: SocialLoginType, options?: SocialLoginOptions): Promise<SocialLoginResult>
   getAuthStatus(): Promise<{ isLoggedIn: boolean }>
   getAuthToken(): Promise<{ accessToken: string | null }>
   logout({ clearAll }: { clearAll?: boolean }): Promise<{ success: boolean; message?: string }>


### PR DESCRIPTION
## 이슈 번호

> #MM-160

## 작업내용  
- 변경한 주요 내용 목록  
  - 브릿지를 통해 웹 -> 네이티브로 device Id 전달
  - 소셜 로그인 요청에 디바이스 id 추가

## 리뷰어에게 전할 말  
- 

## 스크린샷 (선택사항)

<!-- 필요한 경우 스크린샷을 첨부해주세요 -->
