### PR TITLE
[FIX/MM-164] 인증 전환 시 Webview 히스토리 초기화

### DIFF
--- a/apps/mobile/app/bridge/index.ts
+++ b/apps/mobile/app/bridge/index.ts
@@ -45,6 +45,7 @@ export const appBridge = bridge<AppBridgeState>(({ get, set }) => {
 
     async getAuthStatus(): Promise<{ isLoggedIn: boolean }> {
       const isLoggedIn = await AuthStorage.isAuthenticated()
+      set({ isLoggedIn })
       return { isLoggedIn }
     },
 

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -21,7 +21,7 @@ SplashScreen.preventAutoHideAsync()
 
 export default function App() {
   const webviewRef = useRef<BridgeWebView>(null)
-  const { setKeyboardHeight, isModalOpen, setModalOpen } = useBridge(appBridge)
+  const { setKeyboardHeight, isModalOpen, setModalOpen, isLoggedIn } = useBridge(appBridge)
   const insets = useSafeAreaInsets()
   const [showSplash, setShowSplash] = useState(true)
   const [canGoBack, setCanGoBack] = useState(false)
@@ -47,6 +47,10 @@ export default function App() {
       hideSub.remove()
     }
   }, [insets.bottom, setKeyboardHeight])
+
+  useEffect(() => {
+    setCanGoBack(false)
+  }, [isLoggedIn])
 
   const handleRetry = useCallback(() => {
     webviewRef.current?.reload()
@@ -82,6 +86,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <WebView
+        key={String(isLoggedIn)}
         ref={webviewRef}
         source={{ uri: webviewUrl }}
         overScrollMode="never"


### PR DESCRIPTION
## 이슈 번호

> #MM-164

## 작업내용  
- 변경한 주요 내용 목록  
  - 브릿지 상태 isLoggedIn으로 웹뷰 키 설정

## 리뷰어에게 전할 말  
- 브릿지로 컨트롤하면 웹뷰를 쭉 가져갈 수 있긴하지만 코드가 복잡해져서 최대한 간단하게 해결하는 방향으로 수정했습니다

## 스크린샷 (선택사항)

<!-- 필요한 경우 스크린샷을 첨부해주세요 -->
