### PR TITLE
[FIX/MM-165] 채팅 레이아웃 수정 및 API 호출 시점 변경

### DIFF
--- a/apps/react/src/app/__root.tsx
+++ b/apps/react/src/app/__root.tsx
@@ -28,6 +28,8 @@ const onboardingRoutes = [
   '/onboarding/complete',
 ]
 
+const coupleFlowRoutes = ['/onboarding/partner-code', '/onboarding/anniversary']
+
 function matchRoute(routes: string[], path: string) {
   return routes.some((route) => match(route)(path))
 }
@@ -41,6 +43,9 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     // --- 인증 기반 라우팅 규칙 ---
     const isOnLoginRoute = pathname === '/login'
     const isOnOnboardingRoute = matchRoute(onboardingRoutes, pathname)
+    const isCoupleFlowRoute = matchRoute(coupleFlowRoutes, pathname)
+    const search = (location.search ?? {}) as Record<string, unknown>
+    const isCoupleFlowAccess = isCoupleFlowRoute && (search?.coupleFlow === true || search?.coupleFlow === 'true')
 
     // 1. 인증된 사용자
     if (authenticated) {
@@ -53,7 +58,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
         throw redirect({ to: '/onboarding/terms' })
       }
       // 규칙 3: 온보딩을 마쳤는데 온보딩 경로로 접근 시, 홈으로 리다이렉트
-      if (!needsOnboarding && isOnOnboardingRoute) {
+      if (!needsOnboarding && isOnOnboardingRoute && !isCoupleFlowAccess) {
         throw redirect({ to: '/' })
       }
       return // 모든 규칙 통과 시 접근 허용

--- a/apps/react/src/app/chat/page.tsx
+++ b/apps/react/src/app/chat/page.tsx
@@ -145,7 +145,7 @@ function RouteComponent() {
 
   return (
     <Screen>
-      <Screen.Header behavior="overlay">
+      <Screen.Header>
         <DetailHeaderBar
           right={chatId ? undefined : exitButton()}
           title={chatId ? formatDate(messages[0]?.createdAt, 'YYYY년 MM월 DD일') : ''}

--- a/apps/react/src/app/chat/page.tsx
+++ b/apps/react/src/app/chat/page.tsx
@@ -75,7 +75,8 @@ function RouteComponent() {
   const { ref } = useInfiniteScroll({ hasNextPage, isFetchingNextPage, fetchNextPage })
 
   const messages = useMemo(() => {
-    if (chattingModal.showChattingTutorial && chatStatus === ChatRoomStateDataChatRoomStateEnum.BeforeInit) return []
+    if (!chatId && chattingModal.showChattingTutorial && chatStatus === ChatRoomStateDataChatRoomStateEnum.BeforeInit)
+      return []
     if (!data || !auth.userInfo.loveTypeCategory) return []
     const allMessages = data.pages.flatMap((page) => page?.list ?? [])
     return chatId ? allMessages : [...allMessages].reverse()
@@ -221,7 +222,7 @@ function RouteComponent() {
         </div>
       </Screen.Content>
       <ChatInput disabled={!!chatId} />
-      {chattingModal.showChattingTutorial && chattingModal.chattingTutorialModal()}
+      {!chatId && chattingModal.showChattingTutorial && chattingModal.chattingTutorialModal()}
     </Screen>
   )
 }

--- a/apps/react/src/app/chat/result/page.tsx
+++ b/apps/react/src/app/chat/result/page.tsx
@@ -90,7 +90,7 @@ function RouteComponent() {
         />
       </Screen.Header>
 
-      <Screen.Content className="flex flex-col bg-malmo-rasberry-25 pt-3">
+      <Screen.Content className="no-bounce-scroll flex flex-col bg-malmo-rasberry-25 pt-3">
         <ChatResultHeader
           title="대화 요약이 완료되었어요!"
           description={'모모가 고민을 해결하는 데<br /> 도움을 주었길 바라요'}

--- a/apps/react/src/app/my-page/couple-management/anniversary/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/anniversary/page.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { AnniversaryLayout, useAnniversary, useUpdateStartDate } from '@/features/anniversary'
 import { useAuth } from '@/features/auth'
 import { wrapWithTracking, BUTTON_NAMES, CATEGORIES } from '@/shared/analytics'
+import { formatDate } from '@/shared/utils/date'
 
 export const Route = createFileRoute('/my-page/couple-management/anniversary/')({
   component: CoupleManagementAnniversary,
@@ -26,7 +27,8 @@ function CoupleManagementAnniversary() {
       anniversary.state.visibleMonth - 1,
       anniversary.state.visibleDay
     )
-    const startLoveDate = finalDate.toISOString().split('T')[0]
+    console.log('finalDate', finalDate)
+    const startLoveDate = formatDate(finalDate)
 
     try {
       await updateStartDateMutation.mutateAsync({ startLoveDate: startLoveDate ?? '' })

--- a/apps/react/src/app/my-page/couple-management/anniversary/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/anniversary/page.tsx
@@ -1,32 +1,27 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { AnniversaryLayout, useAnniversary, useUpdateStartDate } from '@/features/anniversary'
-import { useOnboarding } from '@/features/onboarding/contexts/onboarding-context'
-import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboarding-navigation'
-import { wrapWithTracking } from '@/shared/analytics'
-import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { wrapWithTracking, BUTTON_NAMES, CATEGORIES } from '@/shared/analytics'
 
-export const Route = createFileRoute('/onboarding/anniversary/')({
-  component: OnboardingAnniversary,
+export const Route = createFileRoute('/my-page/couple-management/anniversary/')({
+  component: CoupleManagementAnniversary,
 })
 
-function OnboardingAnniversary() {
-  const { goToNextStep } = useOnboardingNavigation()
-  const { data, updateAnniversary } = useOnboarding()
-  const anniversary = useAnniversary(data.anniversary)
+function CoupleManagementAnniversary() {
+  const navigate = useNavigate()
+  const anniversary = useAnniversary(null)
   const updateStartDateMutation = useUpdateStartDate(async () => {
-    goToNextStep()
+    navigate({ to: '/my-page/couple-management', replace: true })
   })
 
   const handleNext = wrapWithTracking(BUTTON_NAMES.NEXT_ANNIVERSARY, CATEGORIES.ONBOARDING, async () => {
+    if (updateStartDateMutation.isPending) return
+
     const finalDate = new Date(
       anniversary.state.visibleYear,
       anniversary.state.visibleMonth - 1,
       anniversary.state.visibleDay
     )
-    updateAnniversary(finalDate)
-
-    if (updateStartDateMutation.isPending) return
     const startLoveDate = finalDate.toISOString().split('T')[0]
 
     try {
@@ -36,12 +31,17 @@ function OnboardingAnniversary() {
     }
   })
 
+  const handleBack = wrapWithTracking(BUTTON_NAMES.BACK_ANNIVERSARY, CATEGORIES.ONBOARDING, () => {
+    navigate({ to: '/my-page/couple-management', replace: true })
+  })
+
   return (
     <AnniversaryLayout
       anniversary={anniversary}
       onSubmit={handleNext}
       isSubmitting={updateStartDateMutation.isPending}
-      showBackButton={false}
+      showBackButton={true}
+      onBack={handleBack}
     />
   )
 }

--- a/apps/react/src/app/my-page/couple-management/anniversary/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/anniversary/page.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { AnniversaryLayout, useAnniversary, useUpdateStartDate } from '@/features/anniversary'
+import { useAuth } from '@/features/auth'
 import { wrapWithTracking, BUTTON_NAMES, CATEGORIES } from '@/shared/analytics'
 
 export const Route = createFileRoute('/my-page/couple-management/anniversary/')({
@@ -10,7 +11,10 @@ export const Route = createFileRoute('/my-page/couple-management/anniversary/')(
 function CoupleManagementAnniversary() {
   const navigate = useNavigate()
   const anniversary = useAnniversary(null)
+  const { refreshUserInfo } = useAuth()
+
   const updateStartDateMutation = useUpdateStartDate(async () => {
+    await refreshUserInfo()
     navigate({ to: '/my-page/couple-management', replace: true })
   })
 

--- a/apps/react/src/app/my-page/couple-management/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/page.tsx
@@ -1,13 +1,12 @@
 import { PartnerMemberDataMemberStateEnum } from '@data/user-api-axios/api'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { createFileRoute, useRouter } from '@tanstack/react-router'
-import { useState } from 'react'
+import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router'
 
 import ClipBoardIcon from '@/assets/icons/clip-board.svg'
 import { AnniversaryEditSheet } from '@/features/anniversary'
 import { useAuth } from '@/features/auth'
 import { usePartnerInfo } from '@/features/member/hooks/use-partner-info'
-import { PartnerCodeSheet, useProfileEdit, useProfileModal } from '@/features/profile'
+import { useProfileEdit, useProfileModal } from '@/features/profile'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { Screen } from '@/shared/layout/screen'
@@ -25,15 +24,15 @@ export const Route = createFileRoute('/my-page/couple-management/')({
 
 function CoupleManagementPage() {
   const router = useRouter()
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { data: inviteCodeData } = useQuery(memberService.inviteCodeQuery())
   const inviteCode = inviteCodeData?.data?.coupleCode || ''
-  const [isPartnerCodeSheetOpen, setIsPartnerCodeSheetOpen] = useState(false)
   const { refreshUserInfo } = useAuth()
   const profileEdit = useProfileEdit()
 
   // 프로필 모달 훅
-  const { coupleDisconnectModal, coupleConnectedModal } = useProfileModal()
+  const { coupleDisconnectModal } = useProfileModal()
 
   // 커플 연동 상태
   const { data: partnerInfo } = usePartnerInfo()
@@ -64,7 +63,7 @@ function CoupleManagementPage() {
 
   const handleConnectPartner = wrapWithTracking(BUTTON_NAMES.OPEN_PARTNER_SHEET, CATEGORIES.PROFILE, () => {
     if (isPartnerConnected) return
-    setIsPartnerCodeSheetOpen(true)
+    navigate({ to: '/onboarding/partner-code', search: { coupleFlow: true }, replace: true })
   })
 
   const handleDisconnectCouple = wrapWithTracking(BUTTON_NAMES.DISCONNECT_COUPLE, CATEGORIES.PROFILE, () =>
@@ -126,13 +125,6 @@ function CoupleManagementPage() {
           </button>
         </div>
       </Screen.Content>
-
-      <PartnerCodeSheet
-        isOpen={isPartnerCodeSheetOpen}
-        onOpenChange={setIsPartnerCodeSheetOpen}
-        onSuccess={handleRefreshPage}
-        onCoupleConnected={coupleConnectedModal}
-      />
 
       <AnniversaryEditSheet
         isOpen={profileEdit.isAnniversarySheetOpen}

--- a/apps/react/src/app/my-page/couple-management/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/page.tsx
@@ -63,7 +63,7 @@ function CoupleManagementPage() {
 
   const handleConnectPartner = wrapWithTracking(BUTTON_NAMES.OPEN_PARTNER_SHEET, CATEGORIES.PROFILE, () => {
     if (isPartnerConnected) return
-    navigate({ to: '/onboarding/partner-code', search: { coupleFlow: true }, replace: true })
+    navigate({ to: '/my-page/couple-management/partner-code', replace: true })
   })
 
   const handleDisconnectCouple = wrapWithTracking(BUTTON_NAMES.DISCONNECT_COUPLE, CATEGORIES.PROFILE, () =>

--- a/apps/react/src/app/my-page/couple-management/partner-code/page.tsx
+++ b/apps/react/src/app/my-page/couple-management/partner-code/page.tsx
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+
+import { useAuth } from '@/features/auth'
+import { PartnerCodeForm } from '@/features/couple'
+import { usePartnerInfo } from '@/features/member'
+import { wrapWithTracking, BUTTON_NAMES, CATEGORIES } from '@/shared/analytics'
+import coupleService from '@/shared/services/couple.service'
+import { queryKeys } from '@/shared/services/query-keys'
+import { toast } from '@/shared/ui/toast'
+
+export const Route = createFileRoute('/my-page/couple-management/partner-code/')({
+  component: CoupleManagementPartnerCode,
+})
+
+function CoupleManagementPartnerCode() {
+  const [partnerCode, setPartnerCode] = useState('')
+  const connectCoupleMutation = useMutation({ ...coupleService.connectCoupleMutation() })
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { refreshUserInfo } = useAuth()
+  const { data: partnerInfo, refetch: refetchPartnerInfo } = usePartnerInfo()
+
+  const handlePrevious = wrapWithTracking(BUTTON_NAMES.BACK_PARTNER_CODE, CATEGORIES.ONBOARDING, () => {
+    navigate({ to: '/my-page/couple-management', replace: true })
+  })
+
+  const handleNext = wrapWithTracking(BUTTON_NAMES.CONNECT_PARTNER, CATEGORIES.ONBOARDING, async () => {
+    if (!partnerCode.trim()) return
+
+    try {
+      await connectCoupleMutation.mutateAsync(partnerCode)
+    } catch {
+      return
+    }
+
+    toast.success('커플 연결이 완료되었어요!')
+
+    await refreshUserInfo()
+    queryClient.removeQueries({ queryKey: queryKeys.member.partnerInfo() })
+    const { data: updatedPartnerInfo } = await refetchPartnerInfo()
+    const hasAnniversary = updatedPartnerInfo?.isStartLoveDateUpdated ?? partnerInfo?.isStartLoveDateUpdated ?? false
+
+    if (hasAnniversary) {
+      navigate({ to: '/my-page/couple-management', replace: true })
+      return
+    }
+
+    navigate({ to: '/my-page/couple-management/anniversary', replace: true })
+  })
+
+  return (
+    <PartnerCodeForm
+      partnerCode={partnerCode}
+      onPartnerCodeChange={setPartnerCode}
+      onBack={handlePrevious}
+      onSubmit={handleNext}
+      isSubmitting={connectCoupleMutation.isPending}
+    />
+  )
+}

--- a/apps/react/src/app/my-page/page.tsx
+++ b/apps/react/src/app/my-page/page.tsx
@@ -51,7 +51,7 @@ function MyPage() {
       </Screen.Header>
 
       {/* 프로필 섹션 */}
-      <Screen.Content className="bg-white">
+      <Screen.Content className="no-bounce-scroll has-bottom-nav flex-1 bg-white">
         <ProfileSection nickname={userInfo.nickname || ''} dDay={dDay} />
 
         {/* 통계 박스 */}
@@ -61,9 +61,7 @@ function MyPage() {
         />
 
         {/* 메뉴 리스트 */}
-        <div className="pb-[60px]">
-          <MenuList menuItems={menuItems} />
-        </div>
+        <MenuList menuItems={menuItems} />
       </Screen.Content>
 
       {/* 하단 네비게이션 */}

--- a/apps/react/src/app/onboarding/anniversary/page.tsx
+++ b/apps/react/src/app/onboarding/anniversary/page.tsx
@@ -5,6 +5,7 @@ import { useOnboarding } from '@/features/onboarding/contexts/onboarding-context
 import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboarding-navigation'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
+import { formatDate } from '@/shared/utils/date'
 
 export const Route = createFileRoute('/onboarding/anniversary/')({
   component: OnboardingAnniversary,
@@ -27,7 +28,7 @@ function OnboardingAnniversary() {
     updateAnniversary(finalDate)
 
     if (updateStartDateMutation.isPending) return
-    const startLoveDate = finalDate.toISOString().split('T')[0]
+    const startLoveDate = formatDate(finalDate)
 
     try {
       await updateStartDateMutation.mutateAsync({ startLoveDate: startLoveDate ?? '' })

--- a/apps/react/src/app/onboarding/anniversary/page.tsx
+++ b/apps/react/src/app/onboarding/anniversary/page.tsx
@@ -1,24 +1,52 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { z } from 'zod'
 
 import { useAnniversary, DatePicker } from '@/features/anniversary'
+import { useAuth } from '@/features/auth'
 import { useOnboarding } from '@/features/onboarding/contexts/onboarding-context'
 import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboarding-navigation'
 import { TitleSection } from '@/features/onboarding/ui/title-section'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { Screen } from '@/shared/layout/screen'
+import memberService from '@/shared/services/member.service'
+import { queryKeys } from '@/shared/services/query-keys'
 import { Button } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 
+const searchSchema = z.object({
+  coupleFlow: z.boolean().optional(),
+})
+
 export const Route = createFileRoute('/onboarding/anniversary/')({
   component: AnniversaryPage,
+  validateSearch: searchSchema,
 })
 
 function AnniversaryPage() {
   const { goToNextStep } = useOnboardingNavigation()
   const { data, updateAnniversary } = useOnboarding()
+  const { coupleFlow } = Route.useSearch()
+  const isCoupleFlow = coupleFlow === true
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { refreshUserInfo } = useAuth()
 
   const { state, actions } = useAnniversary(data.anniversary)
+
+  const startDateOptions = memberService.updateStartDateMutation()
+  const updateStartDateMutation = useMutation({
+    ...startDateOptions,
+    onSuccess: async () => {
+      startDateOptions.onSuccess?.()
+      await refreshUserInfo()
+      queryClient.setQueryData(queryKeys.member.partnerInfo(), null)
+      await queryClient.invalidateQueries({ queryKey: queryKeys.member.partnerInfo() })
+      if (isCoupleFlow) navigate({ to: '/my-page/couple-management', replace: true })
+      else goToNextStep()
+    },
+  })
 
   // const handlePrevious = wrapWithTracking(BUTTON_NAMES.BACK_ANNIVERSARY, CATEGORIES.ONBOARDING, () => {
   //   // 현재 보이는 날짜로 업데이트 후 이전 페이지로 이동
@@ -27,17 +55,25 @@ function AnniversaryPage() {
   //   goToPreviousStep()
   // })
 
-  const handleNext = wrapWithTracking(BUTTON_NAMES.NEXT_ANNIVERSARY, CATEGORIES.ONBOARDING, () => {
+  const handleNext = wrapWithTracking(BUTTON_NAMES.NEXT_ANNIVERSARY, CATEGORIES.ONBOARDING, async () => {
     // 현재 보이는 날짜로 최종 선택하고 다음 페이지로 이동
     const finalDate = new Date(state.visibleYear, state.visibleMonth - 1, state.visibleDay)
     updateAnniversary(finalDate)
-    goToNextStep()
+
+    if (updateStartDateMutation.isPending) return
+    const startLoveDate = finalDate.toISOString().split('T')[0]
+
+    try {
+      await updateStartDateMutation.mutateAsync({ startLoveDate: startLoveDate ?? '' })
+    } catch {
+      return
+    }
   })
 
   return (
     <Screen>
       <Screen.Header behavior="overlay">
-        <DetailHeaderBar showBackButton={false} />
+        <DetailHeaderBar showBackButton={coupleFlow} />
       </Screen.Header>
 
       <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
@@ -65,7 +101,7 @@ function AnniversaryPage() {
         </div>
 
         <div className="mt-auto mb-5 px-5">
-          <Button text="다음" onClick={handleNext} />
+          <Button text="다음" onClick={handleNext} disabled={isCoupleFlow && updateStartDateMutation.isPending} />
         </div>
       </Screen.Content>
     </Screen>

--- a/apps/react/src/app/onboarding/partner-code/page.tsx
+++ b/apps/react/src/app/onboarding/partner-code/page.tsx
@@ -1,52 +1,27 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMutation } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
-import { z } from 'zod'
 
-import { useAuth } from '@/features/auth'
+import { PartnerCodeForm } from '@/features/couple'
 import { useOnboarding } from '@/features/onboarding/contexts/onboarding-context'
 import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboarding-navigation'
-import { TitleSection } from '@/features/onboarding/ui/title-section'
 import { wrapWithTracking } from '@/shared/analytics'
 import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
-import { useKeyboardSheetMotion } from '@/shared/hooks/use-keyboard-motion'
-import { Screen } from '@/shared/layout/screen'
 import coupleService from '@/shared/services/couple.service'
-import memberService from '@/shared/services/member.service'
-import { queryKeys } from '@/shared/services/query-keys'
-import { Button, Input } from '@/shared/ui'
-import { DetailHeaderBar } from '@/shared/ui/header-bar'
 import { toast } from '@/shared/ui/toast'
 
-const searchSchema = z.object({
-  coupleFlow: z.boolean().optional(),
-})
-
 export const Route = createFileRoute('/onboarding/partner-code/')({
-  component: PartnerCodePage,
-  validateSearch: searchSchema,
+  component: OnboardingPartnerCode,
 })
 
-function PartnerCodePage() {
+function OnboardingPartnerCode() {
   const { goToNextStep, goToPreviousStep } = useOnboardingNavigation()
   const { data, updatePartnerCode, completeOnboarding } = useOnboarding()
-  const { keyboardBottom } = useKeyboardSheetMotion()
-
   const [partnerCode, setPartnerCode] = useState(data.partnerCode || '')
 
   const connectCoupleMutation = useMutation({ ...coupleService.connectCoupleMutation() })
 
-  const queryClient = useQueryClient()
-  const navigate = useNavigate()
-  const { refreshUserInfo } = useAuth()
-  const { coupleFlow } = Route.useSearch()
-  const isCoupleFlow = coupleFlow === true
-
   const handlePrevious = wrapWithTracking(BUTTON_NAMES.BACK_PARTNER_CODE, CATEGORIES.ONBOARDING, () => {
-    if (isCoupleFlow) {
-      navigate({ to: '/my-page/couple-management', replace: true })
-      return
-    }
     if (partnerCode.trim()) {
       updatePartnerCode(partnerCode)
     }
@@ -54,33 +29,13 @@ function PartnerCodePage() {
   })
 
   const handleNext = wrapWithTracking(BUTTON_NAMES.CONNECT_PARTNER, CATEGORIES.ONBOARDING, async () => {
-    if (!partnerCode.trim()) {
-      alert('코드를 입력해 주세요.')
-      return
-    }
+    if (!partnerCode.trim()) return
 
     updatePartnerCode(partnerCode)
 
     try {
       await connectCoupleMutation.mutateAsync(partnerCode)
     } catch {
-      return
-    }
-
-    if (isCoupleFlow) {
-      toast.success('커플 연결이 완료되었어요!')
-      await refreshUserInfo()
-      queryClient.setQueryData(queryKeys.member.partnerInfo(), null)
-      await queryClient.invalidateQueries({ queryKey: queryKeys.member.partnerInfo() })
-      const updatedPartnerInfo = await queryClient.ensureQueryData(memberService.partnerInfoQuery())
-      const alreadySetAnniversary = updatedPartnerInfo?.data?.isStartLoveDateUpdated
-
-      if (alreadySetAnniversary) {
-        navigate({ to: '/my-page/couple-management', replace: true })
-      } else {
-        navigate({ to: '/onboarding/anniversary', search: { coupleFlow: true }, replace: true })
-      }
-
       return
     }
 
@@ -92,40 +47,12 @@ function PartnerCodePage() {
   })
 
   return (
-    <Screen>
-      <Screen.Header behavior="overlay">
-        <DetailHeaderBar onBackClick={handlePrevious} />
-      </Screen.Header>
-
-      <Screen.Content className="flex flex-1 flex-col bg-white">
-        <TitleSection
-          title={
-            <>
-              연인의 커플 코드를
-              <br />
-              입력해 주세요
-            </>
-          }
-        />
-
-        <div className="mt-[68px] px-5">
-          <Input
-            type="text"
-            value={partnerCode}
-            onChange={(e) => setPartnerCode(e.target.value)}
-            placeholder="코드를 입력해 주세요"
-            maxLength={7}
-          />
-        </div>
-
-        <div className="mt-auto mb-5 px-5" style={keyboardBottom}>
-          <Button
-            text="연결하기"
-            onClick={handleNext}
-            disabled={connectCoupleMutation.isPending || !partnerCode.trim()}
-          />
-        </div>
-      </Screen.Content>
-    </Screen>
+    <PartnerCodeForm
+      partnerCode={partnerCode}
+      onPartnerCodeChange={setPartnerCode}
+      onBack={handlePrevious}
+      onSubmit={handleNext}
+      isSubmitting={connectCoupleMutation.isPending}
+    />
   )
 }

--- a/apps/react/src/app/onboarding/partner-code/page.tsx
+++ b/apps/react/src/app/onboarding/partner-code/page.tsx
@@ -1,7 +1,9 @@
-import { useMutation } from '@tanstack/react-query'
-import { createFileRoute } from '@tanstack/react-router'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
+import { z } from 'zod'
 
+import { useAuth } from '@/features/auth'
 import { useOnboarding } from '@/features/onboarding/contexts/onboarding-context'
 import { useOnboardingNavigation } from '@/features/onboarding/hooks/use-onboarding-navigation'
 import { TitleSection } from '@/features/onboarding/ui/title-section'
@@ -10,12 +12,19 @@ import { BUTTON_NAMES, CATEGORIES } from '@/shared/analytics/constants'
 import { useKeyboardSheetMotion } from '@/shared/hooks/use-keyboard-motion'
 import { Screen } from '@/shared/layout/screen'
 import coupleService from '@/shared/services/couple.service'
+import memberService from '@/shared/services/member.service'
+import { queryKeys } from '@/shared/services/query-keys'
 import { Button, Input } from '@/shared/ui'
 import { DetailHeaderBar } from '@/shared/ui/header-bar'
 import { toast } from '@/shared/ui/toast'
 
+const searchSchema = z.object({
+  coupleFlow: z.boolean().optional(),
+})
+
 export const Route = createFileRoute('/onboarding/partner-code/')({
   component: PartnerCodePage,
+  validateSearch: searchSchema,
 })
 
 function PartnerCodePage() {
@@ -25,11 +34,19 @@ function PartnerCodePage() {
 
   const [partnerCode, setPartnerCode] = useState(data.partnerCode || '')
 
-  const connectCoupleMutation = useMutation({
-    ...coupleService.connectCoupleMutation(),
-  })
+  const connectCoupleMutation = useMutation({ ...coupleService.connectCoupleMutation() })
+
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { refreshUserInfo } = useAuth()
+  const { coupleFlow } = Route.useSearch()
+  const isCoupleFlow = coupleFlow === true
 
   const handlePrevious = wrapWithTracking(BUTTON_NAMES.BACK_PARTNER_CODE, CATEGORIES.ONBOARDING, () => {
+    if (isCoupleFlow) {
+      navigate({ to: '/my-page/couple-management', replace: true })
+      return
+    }
     if (partnerCode.trim()) {
       updatePartnerCode(partnerCode)
     }
@@ -44,7 +61,28 @@ function PartnerCodePage() {
 
     updatePartnerCode(partnerCode)
 
-    await connectCoupleMutation.mutateAsync(partnerCode)
+    try {
+      await connectCoupleMutation.mutateAsync(partnerCode)
+    } catch {
+      return
+    }
+
+    if (isCoupleFlow) {
+      toast.success('커플 연결이 완료되었어요!')
+      await refreshUserInfo()
+      queryClient.setQueryData(queryKeys.member.partnerInfo(), null)
+      await queryClient.invalidateQueries({ queryKey: queryKeys.member.partnerInfo() })
+      const updatedPartnerInfo = await queryClient.ensureQueryData(memberService.partnerInfoQuery())
+      const alreadySetAnniversary = updatedPartnerInfo?.data?.isStartLoveDateUpdated
+
+      if (alreadySetAnniversary) {
+        navigate({ to: '/my-page/couple-management', replace: true })
+      } else {
+        navigate({ to: '/onboarding/anniversary', search: { coupleFlow: true }, replace: true })
+      }
+
+      return
+    }
 
     const success = await completeOnboarding()
     if (success) {

--- a/apps/react/src/app/question/page.tsx
+++ b/apps/react/src/app/question/page.tsx
@@ -67,7 +67,7 @@ function RouteComponent() {
         <HomeHeaderBar title="마음도감" />
       </Screen.Header>
 
-      <Screen.Content className="has-bottom-nav flex-1 overflow-y-auto overscroll-y-none bg-gray-neutral-100">
+      <Screen.Content className="has-bottom-nav no-bounce-scroll flex-1 bg-gray-neutral-100">
         <div className="bg-white pt-3 pb-7">
           <div className="mb-4 flex items-center justify-between pr-5 pl-[14px]">
             <div className="flex items-center gap-1 py-[2px]">
@@ -149,7 +149,7 @@ function RouteComponent() {
           </div>
         </div>
 
-        <div className="flex-1 px-5 pt-5">
+        <div className="px-5 py-5">
           <Link
             to={selectedQuestion.meAnswered ? '/question/see-answer' : '/question/write-answer'}
             search={{ coupleQuestionId: selectedQuestion?.coupleQuestionId || 0, isEdit: false }}

--- a/apps/react/src/features/anniversary/hooks/use-update-anniversary.ts
+++ b/apps/react/src/features/anniversary/hooks/use-update-anniversary.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { useAuth } from '@/features/auth'
+import memberService from '@/shared/services/member.service'
+import { queryKeys } from '@/shared/services/query-keys'
+
+export function useUpdateStartDate(onCompleted: () => Promise<void> | void) {
+  const queryClient = useQueryClient()
+  const { refreshUserInfo } = useAuth()
+  const baseOptions = memberService.updateStartDateMutation()
+
+  return useMutation({
+    ...baseOptions,
+    onSuccess: async () => {
+      baseOptions.onSuccess?.()
+      await refreshUserInfo()
+      queryClient.setQueryData(queryKeys.member.partnerInfo(), null)
+      await queryClient.invalidateQueries({ queryKey: queryKeys.member.partnerInfo() })
+      await onCompleted()
+    },
+  })
+}

--- a/apps/react/src/features/anniversary/hooks/use-update-anniversary.ts
+++ b/apps/react/src/features/anniversary/hooks/use-update-anniversary.ts
@@ -1,19 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import { useAuth } from '@/features/auth'
 import memberService from '@/shared/services/member.service'
 import { queryKeys } from '@/shared/services/query-keys'
 
 export function useUpdateStartDate(onCompleted: () => Promise<void> | void) {
   const queryClient = useQueryClient()
-  const { refreshUserInfo } = useAuth()
   const baseOptions = memberService.updateStartDateMutation()
 
   return useMutation({
     ...baseOptions,
     onSuccess: async () => {
       baseOptions.onSuccess?.()
-      await refreshUserInfo()
       queryClient.setQueryData(queryKeys.member.partnerInfo(), null)
       await queryClient.invalidateQueries({ queryKey: queryKeys.member.partnerInfo() })
       await onCompleted()

--- a/apps/react/src/features/anniversary/index.ts
+++ b/apps/react/src/features/anniversary/index.ts
@@ -1,6 +1,8 @@
 // 훅 내보내기
 export { useAnniversary } from './hooks/use-anniversary'
+export { useUpdateStartDate } from './hooks/use-update-anniversary'
 
 // UI 컴포넌트 내보내기
 export { DatePicker } from './ui/date-picker'
 export { AnniversaryEditSheet } from './ui/anniversary-edit-sheet'
+export { AnniversaryLayout } from './ui/anniversary-layout'

--- a/apps/react/src/features/anniversary/ui/anniversary-layout.tsx
+++ b/apps/react/src/features/anniversary/ui/anniversary-layout.tsx
@@ -1,0 +1,58 @@
+import { useAnniversary, DatePicker } from '@/features/anniversary'
+import { TitleSection } from '@/features/onboarding/ui/title-section'
+import { Screen } from '@/shared/layout/screen'
+import { Button } from '@/shared/ui'
+import { DetailHeaderBar } from '@/shared/ui/header-bar'
+
+interface AnniversaryLayoutProps {
+  anniversary: ReturnType<typeof useAnniversary>
+  onSubmit: () => void
+  isSubmitting: boolean
+  showBackButton: boolean
+  onBack?: () => void
+}
+
+export function AnniversaryLayout({
+  anniversary,
+  onSubmit,
+  isSubmitting,
+  showBackButton,
+  onBack,
+}: AnniversaryLayoutProps) {
+  return (
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar showBackButton={showBackButton} onBackClick={onBack} />
+      </Screen.Header>
+
+      <Screen.Content className="flex flex-1 flex-col bg-white pb-[var(--safe-bottom)]">
+        <TitleSection
+          title={
+            <>
+              둘의 만남을 시작한 날짜는
+              <br />
+              언제인가요?
+            </>
+          }
+          description={'말모가 기념일을 기억하고 보여드릴게요!'}
+        />
+
+        <div className="mt-[68px] px-5">
+          <DatePicker
+            state={anniversary.state}
+            actions={{
+              handleYearScroll: anniversary.actions.handleYearScroll,
+              handleMonthScroll: anniversary.actions.handleMonthScroll,
+              handleDayScroll: anniversary.actions.handleDayScroll,
+              handleDateChange: anniversary.actions.handleDateChange,
+            }}
+          />
+        </div>
+
+        <div className="mt-auto mb-5 px-5">
+          <Button text="다음" onClick={onSubmit} disabled={isSubmitting} />
+        </div>
+      </Screen.Content>
+    </Screen>
+  )
+}

--- a/apps/react/src/features/couple/index.ts
+++ b/apps/react/src/features/couple/index.ts
@@ -1,0 +1,1 @@
+export * from './ui/couple-code-form'

--- a/apps/react/src/features/couple/ui/couple-code-form.tsx
+++ b/apps/react/src/features/couple/ui/couple-code-form.tsx
@@ -1,0 +1,57 @@
+import { TitleSection } from '@/features/onboarding/ui/title-section'
+import { useKeyboardSheetMotion } from '@/shared/hooks/use-keyboard-motion'
+import { Screen } from '@/shared/layout/screen'
+import { Input, Button } from '@/shared/ui'
+import { DetailHeaderBar } from '@/shared/ui/header-bar'
+
+interface PartnerCodeFormProps {
+  partnerCode: string
+  onPartnerCodeChange: (code: string) => void
+  onBack: () => void
+  onSubmit: () => void
+  isSubmitting: boolean
+}
+
+export function PartnerCodeForm({
+  partnerCode,
+  onPartnerCodeChange,
+  onBack,
+  onSubmit,
+  isSubmitting,
+}: PartnerCodeFormProps) {
+  const { keyboardBottom } = useKeyboardSheetMotion()
+
+  return (
+    <Screen>
+      <Screen.Header behavior="overlay">
+        <DetailHeaderBar onBackClick={onBack} />
+      </Screen.Header>
+
+      <Screen.Content className="flex flex-1 flex-col bg-white">
+        <TitleSection
+          title={
+            <>
+              연인의 커플 코드를
+              <br />
+              입력해 주세요
+            </>
+          }
+        />
+
+        <div className="mt-[68px] px-5">
+          <Input
+            type="text"
+            value={partnerCode}
+            onChange={(e) => onPartnerCodeChange(e.target.value)}
+            placeholder="코드를 입력해 주세요"
+            maxLength={7}
+          />
+        </div>
+
+        <div className="mt-auto mb-5 px-5" style={keyboardBottom}>
+          <Button text="연결하기" onClick={onSubmit} disabled={isSubmitting || !partnerCode.trim()} />
+        </div>
+      </Screen.Content>
+    </Screen>
+  )
+}

--- a/apps/react/src/routeTree.gen.ts
+++ b/apps/react/src/routeTree.gen.ts
@@ -37,6 +37,8 @@ import { Route as HistoryDeletePageImport } from './app/history/delete/page'
 import { Route as ChatResultPageImport } from './app/chat/result/page'
 import { Route as ChatLoadingPageImport } from './app/chat/loading/page'
 import { Route as AttachmentTestQuestionPageImport } from './app/attachment-test/question/page'
+import { Route as MyPageCoupleManagementPartnerCodePageImport } from './app/my-page/couple-management/partner-code/page'
+import { Route as MyPageCoupleManagementAnniversaryPageImport } from './app/my-page/couple-management/anniversary/page'
 import { Route as AttachmentTestResultPartnerPageImport } from './app/attachment-test/result/partner/page'
 import { Route as AttachmentTestResultMyPageImport } from './app/attachment-test/result/my/page'
 
@@ -195,6 +197,18 @@ const ChatLoadingPageRoute = ChatLoadingPageImport.update({
 const AttachmentTestQuestionPageRoute = AttachmentTestQuestionPageImport.update({
   id: '/attachment-test/question/',
   path: '/attachment-test/question/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const MyPageCoupleManagementPartnerCodePageRoute = MyPageCoupleManagementPartnerCodePageImport.update({
+  id: '/my-page/couple-management/partner-code/',
+  path: '/my-page/couple-management/partner-code/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const MyPageCoupleManagementAnniversaryPageRoute = MyPageCoupleManagementAnniversaryPageImport.update({
+  id: '/my-page/couple-management/anniversary/',
+  path: '/my-page/couple-management/anniversary/',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -410,6 +424,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AttachmentTestResultPartnerPageImport
       parentRoute: typeof rootRoute
     }
+    '/my-page/couple-management/anniversary/': {
+      id: '/my-page/couple-management/anniversary/'
+      path: '/my-page/couple-management/anniversary'
+      fullPath: '/my-page/couple-management/anniversary'
+      preLoaderRoute: typeof MyPageCoupleManagementAnniversaryPageImport
+      parentRoute: typeof rootRoute
+    }
+    '/my-page/couple-management/partner-code/': {
+      id: '/my-page/couple-management/partner-code/'
+      path: '/my-page/couple-management/partner-code'
+      fullPath: '/my-page/couple-management/partner-code'
+      preLoaderRoute: typeof MyPageCoupleManagementPartnerCodePageImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -478,6 +506,8 @@ export interface FileRoutesByFullPath {
   '/terms/privacy-policy': typeof TermsPrivacyPolicyPageRoute
   '/attachment-test/result/my': typeof AttachmentTestResultMyPageRoute
   '/attachment-test/result/partner': typeof AttachmentTestResultPartnerPageRoute
+  '/my-page/couple-management/anniversary': typeof MyPageCoupleManagementAnniversaryPageRoute
+  '/my-page/couple-management/partner-code': typeof MyPageCoupleManagementPartnerCodePageRoute
 }
 
 export interface FileRoutesByTo {
@@ -508,6 +538,8 @@ export interface FileRoutesByTo {
   '/terms/privacy-policy': typeof TermsPrivacyPolicyPageRoute
   '/attachment-test/result/my': typeof AttachmentTestResultMyPageRoute
   '/attachment-test/result/partner': typeof AttachmentTestResultPartnerPageRoute
+  '/my-page/couple-management/anniversary': typeof MyPageCoupleManagementAnniversaryPageRoute
+  '/my-page/couple-management/partner-code': typeof MyPageCoupleManagementPartnerCodePageRoute
 }
 
 export interface FileRoutesById {
@@ -540,6 +572,8 @@ export interface FileRoutesById {
   '/terms/privacy-policy/': typeof TermsPrivacyPolicyPageRoute
   '/attachment-test/result/my/': typeof AttachmentTestResultMyPageRoute
   '/attachment-test/result/partner/': typeof AttachmentTestResultPartnerPageRoute
+  '/my-page/couple-management/anniversary/': typeof MyPageCoupleManagementAnniversaryPageRoute
+  '/my-page/couple-management/partner-code/': typeof MyPageCoupleManagementPartnerCodePageRoute
 }
 
 export interface FileRouteTypes {
@@ -573,6 +607,8 @@ export interface FileRouteTypes {
     | '/terms/privacy-policy'
     | '/attachment-test/result/my'
     | '/attachment-test/result/partner'
+    | '/my-page/couple-management/anniversary'
+    | '/my-page/couple-management/partner-code'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -602,6 +638,8 @@ export interface FileRouteTypes {
     | '/terms/privacy-policy'
     | '/attachment-test/result/my'
     | '/attachment-test/result/partner'
+    | '/my-page/couple-management/anniversary'
+    | '/my-page/couple-management/partner-code'
   id:
     | '__root__'
     | '/'
@@ -632,6 +670,8 @@ export interface FileRouteTypes {
     | '/terms/privacy-policy/'
     | '/attachment-test/result/my/'
     | '/attachment-test/result/partner/'
+    | '/my-page/couple-management/anniversary/'
+    | '/my-page/couple-management/partner-code/'
   fileRoutesById: FileRoutesById
 }
 
@@ -655,6 +695,8 @@ export interface RootRouteChildren {
   TermsPrivacyPolicyPageRoute: typeof TermsPrivacyPolicyPageRoute
   AttachmentTestResultMyPageRoute: typeof AttachmentTestResultMyPageRoute
   AttachmentTestResultPartnerPageRoute: typeof AttachmentTestResultPartnerPageRoute
+  MyPageCoupleManagementAnniversaryPageRoute: typeof MyPageCoupleManagementAnniversaryPageRoute
+  MyPageCoupleManagementPartnerCodePageRoute: typeof MyPageCoupleManagementPartnerCodePageRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -677,6 +719,8 @@ const rootRouteChildren: RootRouteChildren = {
   TermsPrivacyPolicyPageRoute: TermsPrivacyPolicyPageRoute,
   AttachmentTestResultMyPageRoute: AttachmentTestResultMyPageRoute,
   AttachmentTestResultPartnerPageRoute: AttachmentTestResultPartnerPageRoute,
+  MyPageCoupleManagementAnniversaryPageRoute: MyPageCoupleManagementAnniversaryPageRoute,
+  MyPageCoupleManagementPartnerCodePageRoute: MyPageCoupleManagementPartnerCodePageRoute,
 }
 
 export const routeTree = rootRoute._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
@@ -705,7 +749,9 @@ export const routeTree = rootRoute._addFileChildren(rootRouteChildren)._addFileT
         "/question/write-answer/",
         "/terms/privacy-policy/",
         "/attachment-test/result/my/",
-        "/attachment-test/result/partner/"
+        "/attachment-test/result/partner/",
+        "/my-page/couple-management/anniversary/",
+        "/my-page/couple-management/partner-code/"
       ]
     },
     "/": {
@@ -813,6 +859,12 @@ export const routeTree = rootRoute._addFileChildren(rootRouteChildren)._addFileT
     },
     "/attachment-test/result/partner/": {
       "filePath": "attachment-test/result/partner/page.tsx"
+    },
+    "/my-page/couple-management/anniversary/": {
+      "filePath": "my-page/couple-management/anniversary/page.tsx"
+    },
+    "/my-page/couple-management/partner-code/": {
+      "filePath": "my-page/couple-management/partner-code/page.tsx"
     }
   }
 }

--- a/apps/react/src/shared/services/chat.service.ts
+++ b/apps/react/src/shared/services/chat.service.ts
@@ -91,8 +91,9 @@ class ChatService extends ChatroomApi {
         const { data } = await this.completeChatRoom()
         return data?.data
       },
-      onError: () => {
+      onError: (error) => {
         toast.error('채팅 완료 처리 중 오류가 발생했습니다')
+        console.error('completeChatRoomMutation error:', error)
       },
     }
   }

--- a/apps/react/src/shared/ui/stacked-outlet.tsx
+++ b/apps/react/src/shared/ui/stacked-outlet.tsx
@@ -81,6 +81,16 @@ export function StackedOutlet({
     }
     lastHandledSnapshotRef.current = snapshot.id
 
+    const goingToLoading = snapshot.toEntry?.location.pathname?.startsWith('/chat/loading')
+
+    if (snapshot.direction === 'forward' && goingToLoading) {
+      setFrozenStack([])
+      setCurrentDirection('forward')
+      snapshot.proceed()
+      clear()
+      return
+    }
+
     if (snapshot.skip) {
       snapshot.proceed()
       clear()


### PR DESCRIPTION
## 이슈 번호

> #MM-165

## 작업내용  
- 변경한 주요 내용 목록  
  - 채팅 2번 렌더링으로 useEffect가 2번 도는 오류 해결
  - 마음도감, 마이페이지 스크롤 정상적으로 수정
  - 디데이 flow 마이페이지와 온보딩 분리

## 리뷰어에게 전할 말  
StackedOutlet가 전환 애니메이션을 위해 /chat/loading을 여러 번 렌더하면서 같은 useEffect가 두 번씩 실행된 게 원인이었어요. 해결은 두 단계로 했습니다.

useIsFrozenRoute()로 현재 인스턴스가 애니메이션용 frozen 뷰인지 체크해서, 라이브 인스턴스에서만 완료 API를 호출하도록 막았습니다.
여전히 StrictMode 재마운트·재렌더가 있을 수 있어서, 모듈 범위의 completionPromise/lastCompletionResult를 둬서 첫 번째 호출만 실제 /chatrooms/current/complete를 보내고, 이후 렌더는 같은 Promise 결과를 공유하도록 했습니다. 이렇게 해서 중복 요청 없이도 로딩 UI는 그대로 유지됩니다.

## 스크린샷 (선택사항)

<!-- 필요한 경우 스크린샷을 첨부해주세요 -->
