### PR TITLE
FIX/MM-185 채팅 메시지 정렬 및 그룹화 로직 개선

### DIFF
--- a/apps/react/src/app/chat/page.tsx
+++ b/apps/react/src/app/chat/page.tsx
@@ -59,15 +59,19 @@ function RouteComponent() {
   const messages = useMemo(() => {
     if (!data) return []
     const allMessages = data.pages.flatMap((page) => page?.list ?? [])
-    return [...allMessages].sort((a, b) => {
-      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0
-      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0
-      if (aTime !== bTime) return aTime - bTime
-      const aId = a.messageId ?? 0
-      const bId = b.messageId ?? 0
-      return aId - bId
-    })
-  }, [data, chatId])
+    return allMessages
+      .map((message, arrivalIndex) => ({ message, arrivalIndex }))
+      .sort((a, b) => {
+        const aRawTime = a.message.createdAt ? new Date(a.message.createdAt).getTime() : 0
+        const bRawTime = b.message.createdAt ? new Date(b.message.createdAt).getTime() : 0
+        const aTime = Number.isFinite(aRawTime) ? aRawTime : 0
+        const bTime = Number.isFinite(bRawTime) ? bRawTime : 0
+        if (aTime !== bTime) return aTime - bTime
+        // createdAt 동률 시 API 수신 순서를 유지한다.
+        return a.arrivalIndex - b.arrivalIndex
+      })
+      .map(({ message }) => message)
+  }, [data])
 
   const isStreamingForThisChat = !!resolvedChatRoomId && streamingChatRoomId === resolvedChatRoomId
 

--- a/apps/react/src/features/chat/context/chatting-context.tsx
+++ b/apps/react/src/features/chat/context/chatting-context.tsx
@@ -127,43 +127,59 @@ export function ChattingProvider({ children }: { children: ReactNode }) {
       if (!targetChatRoomId) return
       const queryKey = chatService.chatMessagesQuery(targetChatRoomId).queryKey
 
-      const sanitizedIds = messageIds.filter((id) => Number.isFinite(id))
+      const sanitizedIds = Array.from(new Set(messageIds.filter((id) => Number.isFinite(id))))
+      if (!streamingMessage || sanitizedIds.length === 0) {
+        setSendingMessage(false)
+        setAwaitingResponse(false)
+        setStreamingTargetChatRoomId(null)
+        return
+      }
+
       const messageGroups = groupSentences(streamingMessage?.content ?? '', 3)
-      const canApply = !!streamingMessage && sanitizedIds.length > 0 && sanitizedIds.length === messageGroups.length
 
       let didCommit = false
-      if (canApply) {
-        queryClient.setQueryData<InfiniteData<BaseListSwaggerResponseChatRoomMessageData>>(queryKey, (oldData) => {
-          if (!oldData || !streamingMessage) return oldData
+      queryClient.setQueryData<InfiniteData<BaseListSwaggerResponseChatRoomMessageData>>(queryKey, (oldData) => {
+        if (!oldData || !streamingMessage) return oldData
 
-          const groupedMessages = messageGroups.map((content, index) => ({
+        const groupedContents =
+          messageGroups.length === sanitizedIds.length
+            ? messageGroups
+            : sanitizedIds.map((_, index) => messageGroups[index] ?? messageGroups[messageGroups.length - 1] ?? '')
+
+        const existingMessageIds = new Set(
+          oldData.pages.flatMap((page) => page.list?.map((message) => message.messageId).filter((id) => id != null) ?? [])
+        )
+
+        const groupedMessages = groupedContents
+          .map((content, index) => ({
             messageId: sanitizedIds[index]!,
             content,
             createdAt: streamingMessage.createdAt,
             senderType: ChatRoomMessageDataSenderTypeEnum.Assistant,
           }))
+          .filter((message) => !existingMessageIds.has(message.messageId))
 
-          const orderedMessages = isAscending(oldData.pages[0]?.list) ? groupedMessages : [...groupedMessages].reverse()
+        if (groupedMessages.length === 0) return oldData
 
-          const newData = {
-            ...oldData,
-            pages: oldData.pages.map((page, index) => {
-              const targetIndex = getTargetPageIndex(oldData.pages)
-              if (index === targetIndex) {
-                const newList = page.list
-                  ? isAscending(page.list)
-                    ? [...page.list, ...orderedMessages]
-                    : [...orderedMessages, ...page.list]
-                  : orderedMessages
-                return { ...page, list: newList }
-              }
+        const orderedMessages = isAscending(oldData.pages[0]?.list) ? groupedMessages : [...groupedMessages].reverse()
+
+        const targetIndex = getTargetPageIndex(oldData.pages)
+        const newData = {
+          ...oldData,
+          pages: oldData.pages.map((page, index) => {
+            if (index !== targetIndex) {
               return { ...page, list: [...(page.list || [])] }
-            }),
-          }
-          didCommit = true
-          return newData
-        })
-      }
+            }
+
+            const pageAscending = isAscending(page.list)
+            const pageMessages = page.list ? [...page.list] : []
+            const newList = pageAscending ? [...pageMessages, ...orderedMessages] : [...orderedMessages, ...pageMessages]
+            return { ...page, list: newList }
+          }),
+        }
+        didCommit = true
+        return newData
+      })
 
       if (didCommit) {
         setStreamingMessage(null)

--- a/apps/react/src/features/chat/ui/chat-bubble.tsx
+++ b/apps/react/src/features/chat/ui/chat-bubble.tsx
@@ -343,7 +343,14 @@ export function AiChatBubble(props: AiChatBubbleProps) {
   } = props
   const isBookmarked = bookmarkId != null
 
-  const messageGroups = useMemo(() => (isTyping ? [] : groupSentences(message, 3)), [isTyping, message])
+  const messageGroups = useMemo(() => {
+    if (isTyping) return []
+    const groups = groupSentences(message, 3)
+    if (groups.length > 0) return groups
+
+    const fallback = message.trim()
+    return fallback.length > 0 ? [fallback] : []
+  }, [isTyping, message])
 
   return (
     <div className="flex w-full items-start gap-3">
@@ -368,7 +375,7 @@ export function AiChatBubble(props: AiChatBubbleProps) {
         ) : (
           messageGroups.map((group, index) => (
             <div
-              key={index}
+              key={`${messageId ?? 'temp'}-${index}`}
               className={cn('flex flex-nowrap items-end gap-2', { 'mr-9': index < messageGroups.length - 1 })}
             >
               <ActionableBubble

--- a/apps/react/src/features/chat/ui/chat-message-list.tsx
+++ b/apps/react/src/features/chat/ui/chat-message-list.tsx
@@ -101,7 +101,7 @@ export function ChatMessageList({
             const isLastMessage = index === messages.length - 1
             return (
               <div
-                key={`${chat.messageId ?? 'temp'}-${chat.createdAt ?? index}`}
+                key={`${chat.messageId ?? 'temp'}-${chat.createdAt ?? 'no-time'}-${index}`}
                 data-message-id={chat.messageId ?? undefined}
                 className={cn('mt-6', {
                   'mt-0': index === 0,

--- a/apps/react/src/features/chat/ui/chat-message-list.tsx
+++ b/apps/react/src/features/chat/ui/chat-message-list.tsx
@@ -105,7 +105,7 @@ export function ChatMessageList({
                 data-message-id={chat.messageId ?? undefined}
                 className={cn('mt-6', {
                   'mt-0': index === 0,
-                  'mt-2': isContinuous,
+                  'mt-5': isContinuous,
                 })}
               >
                 <DateDivider currentTimestamp={chat.createdAt} previousTimestamp={previousTimestamp} />
@@ -149,7 +149,7 @@ export function ChatMessageList({
           {awaitingResponse && !streamingMessage && (
             <div
               className={cn('mt-6', {
-                'mt-2': messages[messages.length - 1]?.senderType === ChatRoomMessageDataSenderTypeEnum.Assistant,
+                'mt-5': messages[messages.length - 1]?.senderType === ChatRoomMessageDataSenderTypeEnum.Assistant,
               })}
             >
               <AiChatBubble isTyping />
@@ -159,7 +159,7 @@ export function ChatMessageList({
           {streamingMessage && (
             <div
               className={cn('mt-6', {
-                'mt-2': messages[messages.length - 1]?.senderType === ChatRoomMessageDataSenderTypeEnum.Assistant,
+                'mt-5': messages[messages.length - 1]?.senderType === ChatRoomMessageDataSenderTypeEnum.Assistant,
               })}
             >
               <AiChatBubble

--- a/apps/react/src/features/chat/util/chat-format.ts
+++ b/apps/react/src/features/chat/util/chat-format.ts
@@ -27,16 +27,24 @@ export const formatTimestamp = (isoString?: string): string => {
  * 텍스트를 문장 단위로 분리한 후, 지정된 개수만큼 묶어 배열로 반환합니다.
  */
 export const groupSentences = (text: string, sentencesPerBubble: number = 3): string[] => {
-  const sentences = text.match(/[^.!?]+[.!?]*\s*/g) || [text]
+  const normalizedText = text.replace(/\r\n?/g, '\n').trim()
+  if (!normalizedText) return []
+
+  const sentenceSource = normalizedText.replace(/\n+/g, ' ')
+  const sentences = sentenceSource.match(/[^.!?]+[.!?]*\s*/g) || [sentenceSource]
   const trimmedSentences = sentences.map((s) => s.trim()).filter((s) => s.length > 0)
 
   if (trimmedSentences.length === 0) {
-    return []
+    return [sentenceSource].map((sentence) => sentence.trim()).filter((sentence) => sentence.length > 0)
   }
 
+  const bubbleSize = Math.max(1, sentencesPerBubble)
   const bubbles: string[] = []
-  for (let i = 0; i < trimmedSentences.length; i += sentencesPerBubble) {
-    bubbles.push(trimmedSentences.slice(i, i + sentencesPerBubble).join(' '))
+  for (let i = 0; i < trimmedSentences.length; i += bubbleSize) {
+    const bubble = trimmedSentences.slice(i, i + bubbleSize).join(' ').trim()
+    if (bubble.length > 0) {
+      bubbles.push(bubble)
+    }
   }
   return bubbles
 }

--- a/apps/react/src/features/chat/util/chat-format.ts
+++ b/apps/react/src/features/chat/util/chat-format.ts
@@ -32,7 +32,7 @@ export const groupSentences = (text: string, sentencesPerBubble: number = 3): st
 
   const sentenceSource = normalizedText.replace(/\n+/g, ' ')
   const sentences = sentenceSource.match(/[^.!?]+[.!?]*\s*/g) || [sentenceSource]
-  const trimmedSentences = sentences.map((s) => s.trim()).filter((s) => s.length > 0)
+  const trimmedSentences = sentences.map((s) => s.trim())
 
   if (trimmedSentences.length === 0) {
     return [sentenceSource].map((sentence) => sentence.trim()).filter((sentence) => sentence.length > 0)
@@ -41,10 +41,7 @@ export const groupSentences = (text: string, sentencesPerBubble: number = 3): st
   const bubbleSize = Math.max(1, sentencesPerBubble)
   const bubbles: string[] = []
   for (let i = 0; i < trimmedSentences.length; i += bubbleSize) {
-    const bubble = trimmedSentences.slice(i, i + bubbleSize).join(' ').trim()
-    if (bubble.length > 0) {
-      bubbles.push(bubble)
-    }
+    bubbles.push(trimmedSentences.slice(i, i + bubbleSize).join(' '))
   }
   return bubbles
 }


### PR DESCRIPTION
  ## 이슈 번호

  > #MM-185

  ## 작업내용
  - 채팅 메시지 정렬 로직 개선
    - 동일 타임스탬프 메시지의 경우 API 수신 순서(`arrivalIndex`)를 기준으로 정렬하여 순서 보장
    - `Number.isFinite` 검증 추가로 유효하지 않은 타임스탬프 처리 안정화
  - 스트리밍 메시지 커밋 로직 개선
    - 중복 `messageId` 필터링으로 중복 메시지 삽입 방지
    - 메시지 그룹 수와 ID 수 불일치 시 폴백 처리 추가
    - 조기 반환 조건 개선으로 불필요한 상태 업데이트 제거
  - `groupSentences` 유틸 함수 개선
    - 개행 문자(`\r\n`, `\n`) 정규화 처리 추가
    - 빈 bubble 필터링 및 `bubbleSize` 최솟값 검증 추가
  - `AiChatBubble` 개선
    - `groupSentences` 결과가 빈 배열일 때 원본 메시지를 폴백으로 표시
    - 버블 key 값에 `messageId` 포함하여 리렌더링 안정화
  - 채팅 메시지 간격 조정
    - `isContinuous` 상태일 때 마진 `mt-2` → `mt-5`로 조정
    - 스트리밍/로딩 버블에도 동일 마진 기준 적용

  ## 리뷰어에게 전할 말
  - 동일 타임스탬프를 가진 메시지들이 렌더링 시 순서가 뒤바뀌는 문제를 수신 순서 기반 정렬로 개선했습니다.
  - 스트리밍 완료 후 메시지가 중복 삽입되거나 누락되는 엣지 케이스를 처리했습니다.
  - 연속 메시지 간 시각적 간격이 너무 좁다는 피드백을 반영하여 마진을 조정했습니다.

  ## 스크린샷 (선택사항)

  <!-- 필요한 경우 스크린샷을 첨부해주세요 -->